### PR TITLE
fix: 事件收敛逻辑异常 --bug=133902231

### DIFF
--- a/src/backend/services/web/risk/handlers/risk.py
+++ b/src/backend/services/web/risk/handlers/risk.py
@@ -171,7 +171,7 @@ class RiskHandler:
                     & Q(
                         ~Q(status=RiskStatus.CLOSED)
                         | Q(
-                            event_end_time__lte=datetime.datetime.fromtimestamp(
+                            event_end_time__gte=datetime.datetime.fromtimestamp(
                                 event["event_time"] / 1000, tz=timezone.get_default_timezone()
                             )
                         )


### PR DESCRIPTION
1. 修复因为收敛比较逻辑写反导致的风险关闭后，新上报的事件不会生成新的风险。事件收敛的逻辑：如果关闭的历史风险关联的事件时间大于等于新上报的事件时间，就不生成新的风险。

(cherry picked from commit 9a2c3839f08111034ed9c3d3d553f37b7bf3cf33)