### PR TITLE
feat: 规则审计-联表管理-后端接口 --story=121324647

### DIFF
--- a/src/backend/services/web/strategy_v2/resources.py
+++ b/src/backend/services/web/strategy_v2/resources.py
@@ -908,11 +908,13 @@ class UpdateLinkTable(LinkTableBase):
 class DeleteLinkTable(LinkTableBase):
     name = gettext_lazy("删除联表")
 
+    @transaction.atomic()
     def perform_request(self, validated_request_data):
         uid = validated_request_data["uid"]
         # 如果有策略使用了该联表则不能删除
         if Strategy.objects.filter(strategy_type=StrategyType.RULE, link_table_uid=uid).exists():
             raise LinkTableHasStrategy()
+        LinkTableTag.objects.filter(link_table_uid=uid).delete()
         LinkTable.objects.filter(uid=uid).delete()
 
 


### PR DESCRIPTION
【修复】
1. 联表删除同时会删除联表标签