### PR TITLE
feat: 规则审计-联表管理-后端接口 --story=121324647

### DIFF
--- a/src/backend/core/kafka.py
+++ b/src/backend/core/kafka.py
@@ -39,6 +39,7 @@ class KafkaRecordConsumer:
         while True:
             data = self.consumer.poll(timeout_ms=self.timeout_ms, max_records=self.max_records)
             if not data:
+                logger.info(f"[{self.__class__.__name__}] no message received, wait {self.sleep_time}s ...")
                 if not self.sleep_wait:
                     return
                 time.sleep(self.sleep_time)

--- a/src/backend/services/web/strategy_v2/resources.py
+++ b/src/backend/services/web/strategy_v2/resources.py
@@ -954,6 +954,7 @@ class ListLinkTable(LinkTableBase):
             for strategy in Strategy.objects.filter(strategy_type=StrategyType.RULE, link_table_uid__in=link_table_uids)
             .values("link_table_uid")
             .annotate(count=Count("link_table_uid"))
+            .order_by()
         }
         for link_table in link_tables:
             # 填充关联的策略数


### PR DESCRIPTION
【修复】
1. 修复联表列表显示关联策略数异常