### PR TITLE
feat: 规则审计-策略新增/编辑-后端接口 --story=121513458

### DIFF
--- a/src/backend/locale/en/LC_MESSAGES/django.po
+++ b/src/backend/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-13 13:47+0800\n"
+"POT-Creation-Date: 2025-01-16 16:23+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,9 @@ msgstr "Get Result Tables"
 
 msgid "获取结果表"
 msgstr "Get Result Table"
+
+msgid "获取结果表的存储信息"
+msgstr "Get Rt Storages"
 
 msgid "列举项目相关数据"
 msgstr "Get Project Data"
@@ -2148,6 +2151,9 @@ msgstr "Batch Join"
 msgid "Batch"
 msgstr "Batch"
 
+msgid "Redis KV"
+msgstr "Redis KV"
+
 msgid "CDC"
 msgstr "CDC"
 
@@ -3704,9 +3710,6 @@ msgstr "control_id and control_version are required when strategy_type is model"
 
 msgid "Control Version not Exists"
 msgstr "Control Version not Exists"
-
-msgid "link_table_uid and link_table_version are required when strategy_type is rule and config_type is link table"
-msgstr "link_table_uid and link_table_version are required when strategy_type is rule and config_type is link table"
 
 #, python-format
 msgid "%s Need to configure mapping"

--- a/src/backend/locale/zh_CN/LC_MESSAGES/django.po
+++ b/src/backend/locale/zh_CN/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-13 13:47+0800\n"
+"POT-Creation-Date: 2025-01-16 16:23+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,9 @@ msgstr "获取结果表列表"
 
 msgid "获取结果表"
 msgstr "获取结果表"
+
+msgid "获取结果表的存储信息"
+msgstr "获取结果表的存储信息"
 
 msgid "列举项目相关数据"
 msgstr "列举项目相关数据"
@@ -2148,6 +2151,9 @@ msgstr "离线维表计算"
 msgid "Batch"
 msgstr "离线实时计算"
 
+msgid "Redis KV"
+msgstr "Redis KV"
+
 msgid "CDC"
 msgstr "CDC"
 
@@ -3704,9 +3710,6 @@ msgstr "当策略类型为模型审计时，必须提供 control_id 和 control_
 
 msgid "Control Version not Exists"
 msgstr "控件版本不存在"
-
-msgid "link_table_uid and link_table_version are required when strategy_type is rule and config_type is link table"
-msgstr "当策略类型为规则审计并且配置类型为联表时，必须提供 link_table_uid 和 link_table_version"
 
 #, python-format
 msgid "%s Need to configure mapping"

--- a/src/backend/services/web/risk/management/commands/gen_risk.py
+++ b/src/backend/services/web/risk/management/commands/gen_risk.py
@@ -17,7 +17,9 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import json
+from time import sleep
 
+from blueapps.utils.logger import logger
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from kafka import KafkaConsumer
@@ -37,8 +39,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs) -> None:
         config: dict = settings.KAFKA_CONFIG
-        if not config:
-            return
+        while True:
+            logger.info("Waiting for kafka config...")
+            if config:
+                break
+            sleep(5)
         consumer = KafkaConsumer(
             **config,
             value_deserializer=lambda v: json.loads(v.decode("utf-8")),

--- a/src/backend/services/web/strategy_v2/serializers.py
+++ b/src/backend/services/web/strategy_v2/serializers.py
@@ -111,13 +111,10 @@ class StrategySerializer(serializers.Serializer):
         elif strategy_type == StrategyType.RULE.value:
             if validated_request_data.get("configs", {}).get("config_type") != RuleAuditConfigType.LINK_TABLE:
                 return
-            if not (validated_request_data.get("link_table_uid") and validated_request_data.get("link_table_version")):
-                raise serializers.ValidationError(
-                    gettext(
-                        "link_table_uid and link_table_version are required when strategy_type is rule "
-                        "and config_type is link table"
-                    ),
-                )
+            link_table = validated_request_data.get("configs", {}).get("data_source", {}).get("link_table", {})
+            # 提取策略内的联表信息
+            validated_request_data["link_table_uid"] = link_table.get("uid")
+            validated_request_data["link_table_version"] = link_table.get("version")
 
     def _validate_configs(self, validated_request_data: dict):
         """
@@ -196,8 +193,6 @@ class CreateStrategyRequestSerializer(StrategySerializer, serializers.ModelSeria
             "strategy_name",
             "control_id",
             "control_version",
-            "link_table_uid",
-            "link_table_version",
             "strategy_type",
             "configs",
             "tags",
@@ -274,8 +269,6 @@ class UpdateStrategyRequestSerializer(StrategySerializer, serializers.ModelSeria
             "strategy_name",
             "control_id",
             "control_version",
-            "link_table_uid",
-            "link_table_version",
             "strategy_type",
             "configs",
             "tags",


### PR DESCRIPTION
【优化】
1. 创建或更新策略不需要冗余传入联表信息
2. 未配置 kafka 时不会导致生成风险进程退出