### PR TITLE
feat: 规则审计-策略新增/编辑-后端接口 --story=121513458

### DIFF
--- a/src/backend/core/sql/constants.py
+++ b/src/backend/core/sql/constants.py
@@ -103,6 +103,8 @@ class Operator(TextChoices):
     ISNULL = "isnull", gettext_lazy("IsNull")
     NOTNULL = "notnull", gettext_lazy("NotNull")
 
+    range_operators = {INCLUDE, EXCLUDE}
+
     @classmethod
     def match_handler(cls, operator: str):
         return {

--- a/src/backend/core/sql/sql_builder.py
+++ b/src/backend/core/sql/sql_builder.py
@@ -158,9 +158,13 @@ class SQLGenerator:
             raise UnsupportedOperatorError(operator)
 
         # 根据操作符类型调用对应的处理函数
-        if operator in {Operator.INCLUDE, Operator.EXCLUDE}:
-            return handler(field, condition.filters)
-        return handler(field, condition.filter)
+        if operator in Operator.range_operators:
+            condition_value = condition.filters
+        elif not condition.filter and condition.filters:
+            condition_value = condition.filters[0]
+        else:
+            condition_value = condition.filter
+        return handler(field, condition_value)
 
     def _apply_where_conditions(self, where_condition: WhereCondition) -> BasicCriterion:
         """递归构建 WHERE 子句"""

--- a/src/backend/services/web/strategy_v2/handlers/rule_audit.py
+++ b/src/backend/services/web/strategy_v2/handlers/rule_audit.py
@@ -187,7 +187,8 @@ class RuleAuditSQLBuilder:
 
             # link_fields
             link_fields_list = [
-                LinkField(left_field=lf["left_field"], right_field=lf["right_field"]) for lf in lk["link_fields"]
+                LinkField(left_field=lf["left_field"]["field_name"], right_field=lf["right_field"]["field_name"])
+                for lf in lk["link_fields"]
             ]
 
             # 构建 JoinTable

--- a/src/backend/services/web/strategy_v2/serializers.py
+++ b/src/backend/services/web/strategy_v2/serializers.py
@@ -750,13 +750,31 @@ class LinkTableConfigTableSerializer(serializers.Serializer):
         return attrs
 
 
+class LinkTableLinkFieldInfoSerializer(serializers.Serializer):
+    """
+    联表连接字段信息
+    """
+
+    field_name = serializers.CharField(label=gettext_lazy("Field Name"))
+    display_name = serializers.CharField(
+        label=gettext_lazy("Display Name"), default=None, allow_blank=True, allow_null=True
+    )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        # display_name 默认值为 field_name
+        if not attrs.get("display_name"):
+            attrs["display_name"] = attrs["field_name"]
+        return attrs
+
+
 class LinkTableLinkFieldSerializer(serializers.Serializer):
     """
     联表连接字段
     """
 
-    left_field = serializers.CharField(label=gettext_lazy("Left Table Field"))
-    right_field = serializers.CharField(label=gettext_lazy("Right Table Field"))
+    left_field = LinkTableLinkFieldInfoSerializer(label=gettext_lazy("Left Table Field"))
+    right_field = LinkTableLinkFieldInfoSerializer(label=gettext_lazy("Right Table Field"))
 
 
 class LinkTableLinkSerializer(serializers.Serializer):

--- a/src/backend/tests/test_strategy_v2/test_rule_audit_sql_formatter.py
+++ b/src/backend/tests/test_strategy_v2/test_rule_audit_sql_formatter.py
@@ -181,7 +181,9 @@ class TestRuleAuditSQLFormatter(TestCase):
             "links": [
                 {
                     "join_type": "left_join",
-                    "link_fields": [{"left_field": "event_id", "right_field": "resource_id"}],
+                    "link_fields": [
+                        {"left_field": {"field_name": "event_id"}, "right_field": {"field_name": "resource_id"}}
+                    ],
                     "left_table": {
                         "rt_id": "log_rt_1",
                         "table_type": LinkTableTableType.EVENT_LOG,
@@ -366,7 +368,12 @@ class TestRuleAuditSQLFormatter(TestCase):
             "links": [
                 {
                     "join_type": "left_join",
-                    "link_fields": [{"left_field": "event_id", "right_field": "resource_id"}],
+                    "link_fields": [
+                        {
+                            "left_field": {"field_name": "event_id", "display_name": "event_id"},
+                            "right_field": {"field_name": "resource_id", "display_name": "resource_id"},
+                        }
+                    ],
                     "left_table": {
                         "rt_id": "log_rt_1",
                         "table_type": LinkTableTableType.EVENT_LOG,
@@ -381,7 +388,12 @@ class TestRuleAuditSQLFormatter(TestCase):
                 },
                 {
                     "join_type": "inner_join",
-                    "link_fields": [{"left_field": "resource_id", "right_field": "host_id"}],
+                    "link_fields": [
+                        {
+                            "left_field": {"field_name": "resource_id", "display_name": "resource_id"},
+                            "right_field": {"field_name": "host_id", "display_name": "host_id"},
+                        }
+                    ],
                     "left_table": {
                         "rt_id": "asset_rt_2",
                         "table_type": LinkTableTableType.BUILD_ID_ASSET,
@@ -391,7 +403,12 @@ class TestRuleAuditSQLFormatter(TestCase):
                 },
                 {
                     "join_type": "left_join",
-                    "link_fields": [{"left_field": "host_id", "right_field": "network_id"}],
+                    "link_fields": [
+                        {
+                            "left_field": {"field_name": "host_id", "display_name": "host_id"},
+                            "right_field": {"field_name": "network_id", "display_name": "network_id"},
+                        }
+                    ],
                     "left_table": {"rt_id": "host_rt_3", "table_type": LinkTableTableType.BIZ_RT, "display_name": "c"},
                     "right_table": {
                         "rt_id": "network_rt_4",


### PR DESCRIPTION
【优化】
1. 创建策略时：后端用单值表达式+filter 不传入+filters 传入时采用 filters 第一个值
2. 联表提供一个展示字段存储字段展示信息