### PR TITLE
feat: 【策略运行】审计调度周期时间逻辑更新-后端变更 --story=121939408

### DIFF
--- a/src/backend/services/web/analyze/utils.py
+++ b/src/backend/services/web/analyze/utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - 审计中心 (BlueKing - Audit Center) available.
+Copyright (C) 2023 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+import datetime
+
+from rest_framework.settings import api_settings
+
+from services.web.analyze.constants import OffsetUnit
+
+
+def calculate_offline_flow_start_time(schedule_period: OffsetUnit):
+    """
+    计算离线任务的开始时间
+    schedule_period: 调度周期类型
+    """
+    # 计算基准时间
+    current_time = datetime.datetime.now()
+
+    # 根据周期类型计算启动时间
+    if schedule_period == OffsetUnit.DAY:
+        # 第二天0点
+        start_time = current_time.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1)
+    elif schedule_period == OffsetUnit.HOUR:
+        # 下一整点小时
+        start_time = current_time.replace(minute=0, second=0, microsecond=0) + datetime.timedelta(hours=1)
+    else:
+        # 其他情况保持当前时间
+        start_time = current_time
+    # 格式化时间字符串
+    start_time_str = start_time.strftime(api_settings.DATETIME_FORMAT)
+    return start_time_str

--- a/src/backend/services/web/esquery/serializers.py
+++ b/src/backend/services/web/esquery/serializers.py
@@ -26,7 +26,6 @@ from rest_framework import serializers
 from rest_framework.settings import api_settings
 
 from api.bk_log.serializers import EsQueryFilterSerializer
-from apps.exceptions import EsQueryMaxLimit
 from apps.meta.utils.fields import ACCESS_TYPE, RESULT_CODE
 from core.utils.tools import format_date_string
 from services.web.databus.constants import PluginSceneChoices
@@ -95,8 +94,6 @@ class EsQuerySearchAttrSerializer(serializers.Serializer):
             ),
             0,
         )
-        if attrs["start"] > ES_MAX_LIMIT:
-            raise EsQueryMaxLimit(message=EsQueryMaxLimit.MESSAGE % {"count": ES_MAX_LIMIT})
         # 时间
         start_time = arrow.get(format_date_string(attrs["start_time"]))
         end_time = arrow.get(format_date_string(attrs["end_time"]))


### PR DESCRIPTION
1. 按天时为调度周期时，更新后，第二天0点为调度周期，第二天0点跑一次
2. 按小时为调度周期时，更新后，下一整点跑一次，并以整点为调度调度时间，下一个整点作为启动时间
3. 去除 ES start 限制