### PR TITLE
feat: 规则审计2.0-策略开放其他/资产数据的实时支持 --story=122328036

### DIFF
--- a/src/backend/services/web/strategy_v2/serializers.py
+++ b/src/backend/services/web/strategy_v2/serializers.py
@@ -1091,7 +1091,9 @@ class RuleAuditSourceTypeCheckReqSerializer(serializers.Serializer):
     config_type = serializers.ChoiceField(
         label=gettext_lazy("Rule Audit Config Type"), choices=RuleAuditConfigType.choices
     )
-    rt_id = serializers.CharField(label=gettext_lazy("Result Table ID"), required=False, allow_null=True)
+    rt_id = serializers.CharField(
+        label=gettext_lazy("Result Table ID"), required=False, allow_null=True, allow_blank=True
+    )
     link_table = RuleAuditLinkTableSerializer(label=gettext_lazy("Link Table"), required=False, allow_null=True)
 
     def validate(self, attrs):


### PR DESCRIPTION
1. 修复策略创建或更新时的校验