### PR TITLE
chore: 工具1期：工具使用-后端接口 --story=125117884

### DIFF
--- a/src/backend/services/web/tool/executor/tool.py
+++ b/src/backend/services/web/tool/executor/tool.py
@@ -150,7 +150,7 @@ class SqlDataSearchExecutor(
         variable_values_for_rendering = {tv.raw_name: tv.value for tv in params.tool_variables}
         # 生成可执行的 SQL
         limit = params.page_size
-        offset = params.page * params.page_size
+        offset = (params.page - 1) * params.page_size
         sql_result = self.analyzer.generate_sql_with_values(
             params=variable_values_for_rendering, limit=limit, offset=offset, with_count=True
         )

--- a/src/backend/services/web/tool/serializers.py
+++ b/src/backend/services/web/tool/serializers.py
@@ -17,7 +17,14 @@ to the current version of the project delivered to anyone in the future.
 """
 from rest_framework import serializers
 
+from services.web.tool.constants import ToolTypeEnum
+
 
 class ExecuteToolReqSerializer(serializers.Serializer):
     uid = serializers.CharField()
     params = serializers.JSONField()
+
+
+class ExecuteToolRespSerializer(serializers.Serializer):
+    data = serializers.DictField()
+    tool_type = serializers.ChoiceField(choices=ToolTypeEnum.choices)


### PR DESCRIPTION
1. 新增 ExecuteToolRespSerializer 序列化器以支持工具执行的响应格式。
2. 更新 ExecuteTool 类，添加详细的工具执行文档和响应结构。
3. 修改 perform_request 方法，返回包含工具类型的响应数据。