### PR TITLE
feat: 风险列表-审计风险列表展示字段的长度需要限制最大字符数返回 --story=124588560

### DIFF
--- a/src/backend/core/utils/page.py
+++ b/src/backend/core/utils/page.py
@@ -16,17 +16,22 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+from typing import Optional
+
 from django.db.models import QuerySet
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.settings import api_settings
 
 
-def paginate_queryset(queryset: QuerySet, request: Request) -> (QuerySet, PageNumberPagination):
+def paginate_queryset(
+    queryset: QuerySet, request: Request, base_queryset: Optional[QuerySet] = None
+) -> (QuerySet, PageNumberPagination):
     """
     分页 QuerySet
     """
 
     page: PageNumberPagination = api_settings.DEFAULT_PAGINATION_CLASS()
     paged_queryset = page.paginate_queryset(queryset=queryset, request=request)
-    return queryset.model.objects.filter(pk__in=[item.pk for item in paged_queryset]), page
+    base_queryset = base_queryset or queryset.model.objects.all()
+    return base_queryset.filter(pk__in=[item.pk for item in paged_queryset]), page

--- a/src/backend/services/web/risk/resources/risk.py
+++ b/src/backend/services/web/risk/resources/risk.py
@@ -138,8 +138,9 @@ class ListRisk(RiskMeta):
         # 获取风险
         order_field = validated_request_data.pop("order_field", "-last_operate_time")
         risks = self.load_risks(validated_request_data).order_by(order_field)
+        base_qs = Risk.annotated_queryset().order_by(order_field)
         # 分页
-        risks, page = paginate_queryset(queryset=risks, request=request)
+        risks, page = paginate_queryset(queryset=risks, request=request, base_queryset=base_qs)
         # 获取关联的经验
         experiences = {
             e["risk_id"]: e["count"]


### PR DESCRIPTION
1.分页会把截断字段给覆盖，重新优化
# Reviewed, transaction id: 48163