### PR TITLE
feat: 审计风险- 审计风险可以基于风险等级排序 --story=127442228

### DIFF
--- a/src/backend/services/web/risk/constants.py
+++ b/src/backend/services/web/risk/constants.py
@@ -634,3 +634,6 @@ class RiskExportField(TextChoices):
 EVENT_EXPORT_FIELD_PREFIX = "event."
 # 风险导出文件名模板
 RISK_EXPORT_FILE_NAME_TMP = gettext_lazy("审计风险_{risk_view_type}_{datetime}.xlsx")
+
+# 风险等级排序字段
+RISK_LEVEL_ORDER_FIELD = "strategy__risk_level"

--- a/src/backend/services/web/tool/resources.py
+++ b/src/backend/services/web/tool/resources.py
@@ -38,6 +38,7 @@ from apps.meta.serializers import EnumMappingSerializer
 from core.models import get_request_username
 from core.sql.parser.model import ParsedSQLInfo
 from core.sql.parser.praser import SqlQueryAnalysis
+from core.utils.data import preserved_order_sort
 from core.utils.page import paginate_data
 from services.web.common.caller_permission import (
     CurrentType,
@@ -77,7 +78,6 @@ from services.web.tool.serializers import (
 )
 from services.web.tool.tool import (
     create_tool_with_config,
-    custom_sort_order,
     recent_tool_usage_manager,
     sync_resource_tags,
 )
@@ -265,7 +265,11 @@ class ListTool(ToolBase):
             queryset = queryset.filter(uid__in=tagged_tool_uids)
 
         if recent_used and recent_tool_uids:
-            queryset = custom_sort_order(queryset, "uid", recent_tool_uids)
+            queryset = preserved_order_sort(
+                queryset,
+                ordering_field="uid",
+                value_list=recent_tool_uids,
+            )
         else:
             queryset = queryset.order_by("-updated_at")
         paged_tools, page = paginate_data(queryset=queryset, request=request)

--- a/src/backend/services/web/tool/tool.py
+++ b/src/backend/services/web/tool/tool.py
@@ -5,7 +5,6 @@ import redis
 from bk_resource import resource
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import QuerySet
 
 from core.utils.data import unique_id
 from services.web.tool.constants import (
@@ -108,39 +107,6 @@ def sync_resource_tags(
         # 批量创建关联
         objs = [relation_model(**{relation_resource_field: resource_uid, "tag_id": t["tag_id"]}) for t in tags]
         relation_model.objects.bulk_create(objs)
-
-
-def custom_sort_order(
-    queryset: QuerySet,
-    ordering_field: str,
-    value_list: List,
-) -> QuerySet:
-    """
-    自定义排序 .
-
-    :param queryset: 查询集
-    :param ordering_field: 排序字段
-    :param value_list: 排序字段排序值列表,从小到大
-    """
-    if not ordering_field:
-        return queryset
-    desc = False
-    if ordering_field.startswith("-"):
-        desc = True
-        ordering_field = ordering_field[1:]
-
-    clauses = " ".join(
-        "WHEN {}='{}' THEN {} ".format(ordering_field, value if isinstance(value, int) else str(value), idx)
-        for idx, value in enumerate(value_list)
-    )
-    ordering = "CASE %s END " % clauses
-
-    if desc:
-        queryset = queryset.extra(select={"ordering": ordering}, order_by=("-ordering",))
-    else:
-        queryset = queryset.extra(select={"ordering": ordering}, order_by=("ordering",))
-
-    return queryset
 
 
 class RecentToolUsageManager:

--- a/src/backend/services/web/tool/views.py
+++ b/src/backend/services/web/tool/views.py
@@ -4,7 +4,11 @@ from bk_resource.viewsets import ResourceRoute, ResourceViewSet
 
 from apps.permission.handlers.drf import AnyOfPermissions
 from core.utils.data import get_value_by_request
-from services.web.tool.permissions import ManageToolPermission, UseToolPermission, CallerContextPermission
+from services.web.tool.permissions import (
+    CallerContextPermission,
+    ManageToolPermission,
+    UseToolPermission,
+)
 
 
 class ToolViewSet(ResourceViewSet):

--- a/src/backend/tests/test_risk/test_list_risk_order_by_strategy_level.py
+++ b/src/backend/tests/test_risk/test_list_risk_order_by_strategy_level.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for sorting risk list by strategy.risk_level using order_field/order_type
+"""
+
+import datetime
+from unittest import mock
+
+from apps.meta.constants import OrderTypeChoices
+from services.web.risk.constants import RiskStatus
+from services.web.risk.models import Risk
+from services.web.risk.resources import ListMineRisk, ListNoticingRisk, ListRisk
+from services.web.strategy_v2.constants import RiskLevel
+from services.web.strategy_v2.models import Strategy
+from tests.base import TestCase
+from tests.utils.request import call_resource_with_request
+
+
+class TestListRiskOrderByStrategyLevel(TestCase):
+    def setUp(self):
+        super().setUp()
+        # Strategies with different risk levels
+        self.strategy_low = Strategy.objects.create(
+            strategy_id=201,
+            strategy_name="S-LOW",
+            risk_level=RiskLevel.LOW,
+        )
+        self.strategy_mid = Strategy.objects.create(
+            strategy_id=202,
+            strategy_name="S-MID",
+            risk_level=RiskLevel.MIDDLE,
+        )
+        self.strategy_high = Strategy.objects.create(
+            strategy_id=203,
+            strategy_name="S-HIGH",
+            risk_level=RiskLevel.HIGH,
+        )
+
+        # Create risks
+        self.risk_low = Risk.objects.create(
+            risk_id="RL-2",
+            title="low",
+            strategy=self.strategy_low,
+            status=RiskStatus.NEW,
+            event_time=datetime.datetime(2023, 1, 1, 10, 0, 0),
+            current_operator=["admin"],
+            notice_users=["guest"],
+        )
+        self.risk_mid = Risk.objects.create(
+            risk_id="RM-2",
+            title="mid",
+            strategy=self.strategy_mid,
+            status=RiskStatus.NEW,
+            event_time=datetime.datetime(2023, 1, 2, 10, 0, 0),
+            current_operator=["someone"],
+            notice_users=["admin"],
+        )
+        self.risk_high = Risk.objects.create(
+            risk_id="RH-2",
+            title="high",
+            strategy=self.strategy_high,
+            status=RiskStatus.NEW,
+            event_time=datetime.datetime(2023, 1, 3, 10, 0, 0),
+            current_operator=["admin"],
+            notice_users=["admin"],
+        )
+
+    @mock.patch("services.web.risk.models.Risk.load_authed_risks")
+    def test_list_risk_sort_by_strategy_level_desc(self, mock_load_authed_risks):
+        mock_load_authed_risks.return_value = Risk.objects.all()
+
+        resp = call_resource_with_request(ListRisk().request, {"order_field": "risk_level", "order_type": "desc"})
+        # Desc custom order: HIGH > MIDDLE > LOW
+        ids = [i["risk_id"] for i in resp["results"]]
+        self.assertEqual(ids, ["RH-2", "RM-2", "RL-2"])
+
+    @mock.patch("services.web.risk.models.Risk.load_authed_risks")
+    def test_list_risk_sort_by_strategy_level_asc(self, mock_load_authed_risks):
+        mock_load_authed_risks.return_value = Risk.objects.all()
+
+        resp = call_resource_with_request(
+            ListRisk().request, {"order_field": "risk_level", "order_type": OrderTypeChoices.ASC}
+        )
+        # Asc custom order: LOW < MIDDLE < HIGH
+        ids = [i["risk_id"] for i in resp["results"]]
+        self.assertEqual(ids, ["RL-2", "RM-2", "RH-2"])
+
+    @mock.patch("services.web.risk.models.Risk.load_authed_risks")
+    def test_list_mine_risk_sort_by_strategy_level_desc(self, mock_load_authed_risks):
+        mock_load_authed_risks.return_value = Risk.objects.all()
+
+        resp = call_resource_with_request(ListMineRisk().request, {"order_field": "risk_level", "order_type": "desc"})
+        # mine has RH-2 and RL-2 -> order: RH-2 then RL-2 (HIGH > LOW in desc custom)
+        ids = [i["risk_id"] for i in resp["results"]]
+        self.assertEqual(ids, ["RH-2", "RL-2"])
+
+    @mock.patch("services.web.risk.models.Risk.load_authed_risks")
+    def test_list_noticing_risk_sort_by_strategy_level_desc(self, mock_load_authed_risks):
+        mock_load_authed_risks.return_value = Risk.objects.all()
+
+        resp = call_resource_with_request(
+            ListNoticingRisk().request, {"order_field": "risk_level", "order_type": "desc"}
+        )
+        # noticing has RH-2 and RM-2 -> order: RH-2 then RM-2 (HIGH > MIDDLE in desc custom)
+        ids = [i["risk_id"] for i in resp["results"]]
+        self.assertEqual(ids, ["RH-2", "RM-2"])

--- a/src/backend/tests/utils/request.py
+++ b/src/backend/tests/utils/request.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from types import SimpleNamespace
+from typing import Any, Callable, Dict
+
+from blueapps.utils.local import request_local
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+
+def call_resource_with_request(func: Callable[..., Any], data: Dict[str, Any]):
+    """
+    Wrap resource call with a DRF Request so resources with bind_request=True
+    receive `_request` as expected.
+    """
+    factory = APIRequestFactory()
+    django_request = factory.post('/fake-url/', data, format='json')
+
+    # default mock user for audit context (both Django and DRF request)
+    mock_user = SimpleNamespace(username='admin', is_authenticated=True)
+    drf_request = Request(django_request)
+    drf_request.user = mock_user
+    setattr(request_local, "request", drf_request)
+    # call resource with kwargs
+    resp = func(_request=drf_request, **data)
+    # normalize: return DRF Response.data when available
+    return resp.data


### PR DESCRIPTION
- 风险列表接口支持基于风险等级排序：ListRisk/ListMineRisk/ListNoticingRisk（按 HIGH>MIDDLE>LOW/LOW<MIDDLE<HIGH 业务顺序）
- 新增通用排序工具 preserved_order_sort（基于 Case/When，安全兼容跨表字段）
- 兼容前端 order_field=risk_level，序列化器自动转换为 strategy__risk_level
- 分页前后均应用排序，保证页面内顺序一致
- 新增测试工具 tests/utils/request.py 注入默认用户并返回 Response.data
- 新增单测 tests/test_risk/test_list_risk_order_by_strategy_level.py 覆盖三个列表视图的升/降序
- 未改业务获取 _request 的逻辑（仅在单测中注入 request 与用户）