### PR TITLE
fix: 完善场景列表统计与残留绑定清理 --bug=0

### DIFF
--- a/src/backend/services/web/scene/resources.py
+++ b/src/backend/services/web/scene/resources.py
@@ -2,7 +2,7 @@
 import abc
 
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.utils.translation import gettext_lazy
 
 from apps.audit.resources import AuditMixinResource
@@ -72,7 +72,10 @@ class ListScene(SceneResource):
     many_response_data = True
 
     def perform_request(self, validated_request_data):
-        queryset = Scene.objects.all()
+        queryset = Scene.objects.annotate(
+            system_count=Count("scene_systems", distinct=True),
+            table_count=Count("scene_tables", distinct=True),
+        )
         if "status" in validated_request_data:
             queryset = queryset.filter(status=validated_request_data["status"])
         if validated_request_data.get("keyword"):
@@ -244,7 +247,15 @@ class DeleteScene(SceneResource):
             raise SceneNotExist()
 
         # 检查是否有关联资源
-        from services.web.scene.models import ResourceBindingScene
+        from services.web.scene.constants import ResourceVisibilityType
+        from services.web.scene.models import ResourceBinding, ResourceBindingScene
+        from services.web.strategy_v2.models import Strategy
+
+        valid_strategy_ids = Strategy.objects.filter(is_deleted=False).values_list("strategy_id", flat=True)
+        ResourceBinding.objects.filter(
+            resource_type=ResourceVisibilityType.STRATEGY,
+            binding_scenes__scene_id=scene.scene_id,
+        ).exclude(resource_id__in=[str(strategy_id) for strategy_id in valid_strategy_ids]).delete()
 
         # 通过 ResourceBindingScene 检查是否有绑定到该场景的资源
         has_resources = ResourceBindingScene.objects.filter(scene_id=scene.scene_id).exists()

--- a/src/backend/services/web/scene/serializers.py
+++ b/src/backend/services/web/scene/serializers.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
+
+from django.db.models import Count
 from rest_framework import serializers
 
 from services.web.scene.binding_validation import validate_platform_visibility_payload
-from services.web.scene.constants import SceneStatus, VisibilityScope
+from services.web.scene.constants import (
+    ResourceVisibilityType,
+    SceneStatus,
+    VisibilityScope,
+)
 from services.web.scene.models import (
     ResourceBinding,
     ResourceBindingScene,
@@ -61,8 +68,92 @@ class SceneDataTableSerializer(serializers.ModelSerializer):
         fields = ["table_id", "filter_rules"]
 
 
+class SceneSystemInputSerializer(serializers.Serializer):
+    system_id = serializers.CharField(max_length=64)
+    is_all_systems = serializers.BooleanField(required=False, default=False)
+    filter_rules = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+
+
+class SceneTableInputSerializer(serializers.Serializer):
+    table_id = serializers.CharField(max_length=128)
+    filter_rules = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+
+
 class SceneListSerializer(serializers.ModelSerializer):
     """场景列表序列化器"""
+
+    system_count = serializers.IntegerField(read_only=True)
+    table_count = serializers.IntegerField(read_only=True)
+    strategy_ids = serializers.SerializerMethodField()
+    risk_count = serializers.SerializerMethodField()
+
+    def _get_scene_related_ids_map(self):
+        if hasattr(self, "_scene_related_ids_map"):
+            return self._scene_related_ids_map
+
+        instance = self.instance
+        if instance is None:
+            self._scene_related_ids_map = {}
+            return self._scene_related_ids_map
+
+        if hasattr(instance, "__iter__") and not isinstance(instance, (dict, str, bytes)):
+            scenes = list(instance)
+        else:
+            scenes = [instance]
+
+        scene_ids = [scene.scene_id for scene in scenes if getattr(scene, "scene_id", None) is not None]
+        if not scene_ids:
+            self._scene_related_ids_map = {}
+            return self._scene_related_ids_map
+
+        raw_scene_strategy_ids_map = defaultdict(set)
+        raw_strategy_ids = set()
+        bindings = ResourceBindingScene.objects.filter(
+            scene_id__in=scene_ids,
+            binding__resource_type=ResourceVisibilityType.STRATEGY,
+        ).values_list("scene_id", "binding__resource_id")
+        for scene_id, strategy_id_str in bindings:
+            try:
+                strategy_id = int(strategy_id_str)
+            except (TypeError, ValueError):
+                continue
+            raw_scene_strategy_ids_map[scene_id].add(strategy_id)
+            raw_strategy_ids.add(strategy_id)
+
+        valid_strategy_ids = set()
+        if raw_strategy_ids:
+            from services.web.strategy_v2.models import Strategy
+
+            valid_strategy_ids = set(
+                Strategy.objects.filter(strategy_id__in=raw_strategy_ids).values_list("strategy_id", flat=True)
+            )
+
+        strategy_risk_count_map = {}
+        if valid_strategy_ids:
+            from services.web.risk.models import Risk
+
+            strategy_risk_count_map = {
+                item["strategy_id"]: item["count"]
+                for item in Risk.objects.filter(strategy_id__in=valid_strategy_ids)
+                .values("strategy_id")
+                .annotate(count=Count("risk_id"))
+            }
+
+        self._scene_related_ids_map = {}
+        for scene_id in scene_ids:
+            scene_strategy_ids = sorted(raw_scene_strategy_ids_map.get(scene_id, set()) & valid_strategy_ids)
+            scene_risk_count = sum(strategy_risk_count_map.get(strategy_id, 0) for strategy_id in scene_strategy_ids)
+            self._scene_related_ids_map[scene_id] = {
+                "strategy_ids": scene_strategy_ids,
+                "risk_count": scene_risk_count,
+            }
+        return self._scene_related_ids_map
+
+    def get_strategy_ids(self, obj):
+        return self._get_scene_related_ids_map().get(obj.scene_id, {}).get("strategy_ids", [])
+
+    def get_risk_count(self, obj):
+        return self._get_scene_related_ids_map().get(obj.scene_id, {}).get("risk_count", 0)
 
     class Meta:
         model = Scene
@@ -78,6 +169,10 @@ class SceneListSerializer(serializers.ModelSerializer):
             "created_by",
             "updated_by",
             "updated_at",
+            "system_count",
+            "table_count",
+            "strategy_ids",
+            "risk_count",
         ]
 
 
@@ -114,8 +209,8 @@ class CreateSceneSerializer(serializers.Serializer):
     description = serializers.CharField(required=False, default="", allow_blank=True)
     managers = serializers.ListField(child=serializers.CharField(), min_length=1)
     users = serializers.ListField(child=serializers.CharField(), required=False, default=list)
-    systems = serializers.ListField(child=serializers.DictField(), required=False, default=list)
-    tables = serializers.ListField(child=serializers.DictField(), required=False, default=list)
+    systems = SceneSystemInputSerializer(many=True, required=False, default=list)
+    tables = SceneTableInputSerializer(many=True, required=False, default=list)
 
 
 class UpdateSceneSerializer(serializers.Serializer):
@@ -126,8 +221,8 @@ class UpdateSceneSerializer(serializers.Serializer):
     description = serializers.CharField(required=False, allow_blank=True)
     managers = serializers.ListField(child=serializers.CharField(), required=False)
     users = serializers.ListField(child=serializers.CharField(), required=False)
-    systems = serializers.ListField(child=serializers.DictField(), required=False)
-    tables = serializers.ListField(child=serializers.DictField(), required=False)
+    systems = SceneSystemInputSerializer(many=True, required=False)
+    tables = SceneTableInputSerializer(many=True, required=False)
 
 
 class SceneInfoUpdateSerializer(serializers.Serializer):

--- a/src/backend/services/web/strategy_v2/resources.py
+++ b/src/backend/services/web/strategy_v2/resources.py
@@ -574,8 +574,15 @@ class DeleteStrategy(StrategyV2Base):
             strategy.save(update_fields=["status", "status_msg"])
             raise err
         # delete strategy
+        from services.web.scene.constants import ResourceVisibilityType
+        from services.web.scene.models import ResourceBinding
+
         self.add_audit_instance_to_context(instance=StrategyAuditInstance(strategy))
         strategy.delete()
+        ResourceBinding.objects.filter(
+            resource_type=ResourceVisibilityType.STRATEGY,
+            resource_id=str(strategy.strategy_id),
+        ).delete()
         self.delete_enum_mappings(strategy_id=strategy.strategy_id)
 
 

--- a/src/backend/tests/test_scene/test_scene.py
+++ b/src/backend/tests/test_scene/test_scene.py
@@ -21,7 +21,9 @@ from bk_resource import resource
 from bk_resource.exceptions import ValidateException
 from django.db.models import Q
 from django.test import RequestFactory
+from django.utils import timezone
 
+from services.web.risk.models import Risk
 from services.web.scene.constants import (
     BindingType,
     PanelCategory,
@@ -43,6 +45,7 @@ from services.web.scene.models import (
     SceneSystem,
 )
 from services.web.scene.permissions import check_scene_permission
+from services.web.strategy_v2.models import Strategy
 from services.web.tool.models import Tool
 from services.web.vision.models import VisionPanel
 from tests.base import TestCase
@@ -604,6 +607,54 @@ class TestSceneResource(TestCase):
         result = self.resource.scene.list_scene({})
         self.assertGreaterEqual(len(result), 1)
 
+    def test_scene_list_contains_related_strategy_ids_and_risk_count(self):
+        """测试场景列表返回关联策略ID和风险数量"""
+        strategy = Strategy.objects.create(strategy_name="场景策略")
+        binding = ResourceBinding.objects.create(
+            resource_type=ResourceVisibilityType.STRATEGY,
+            resource_id=str(strategy.strategy_id),
+            binding_type=BindingType.SCENE_BINDING,
+        )
+        ResourceBindingScene.objects.create(binding=binding, scene_id=self.scene.scene_id)
+        Risk.objects.create(
+            raw_event_id="raw-scene-list-1",
+            strategy=strategy,
+            event_time=timezone.now(),
+            event_end_time=timezone.now(),
+        )
+
+        result = self.resource.scene.list_scene({})
+        target = next(item for item in result if item["scene_id"] == self.scene.scene_id)
+        self.assertIn(strategy.strategy_id, target["strategy_ids"])
+        self.assertEqual(target["risk_count"], 1)
+
+    def test_scene_list_contains_system_count_and_table_count(self):
+        """测试场景列表返回系统和数据表数量"""
+        SceneSystem.objects.create(scene=self.scene, system_id="bk_cmdb", is_all_systems=False, filter_rules=[])
+        SceneSystem.objects.create(scene=self.scene, system_id="bk_iam", is_all_systems=False, filter_rules=[])
+        SceneDataTable.objects.create(scene=self.scene, table_id="table_1", filter_rules=[])
+
+        result = self.resource.scene.list_scene({})
+        target = next(item for item in result if item["scene_id"] == self.scene.scene_id)
+        self.assertEqual(target["system_count"], 2)
+        self.assertEqual(target["table_count"], 1)
+
+    def test_scene_list_ignores_deleted_strategy_binding(self):
+        """测试场景列表忽略已删除策略的残留绑定"""
+        strategy = Strategy.objects.create(strategy_name="已删除场景策略")
+        binding = ResourceBinding.objects.create(
+            resource_type=ResourceVisibilityType.STRATEGY,
+            resource_id=str(strategy.strategy_id),
+            binding_type=BindingType.SCENE_BINDING,
+        )
+        ResourceBindingScene.objects.create(binding=binding, scene_id=self.scene.scene_id)
+        strategy.delete()
+
+        result = self.resource.scene.list_scene({})
+        target = next(item for item in result if item["scene_id"] == self.scene.scene_id)
+        self.assertNotIn(strategy.strategy_id, target["strategy_ids"])
+        self.assertEqual(target["risk_count"], 0)
+
     def test_scene_list_filter_by_status(self):
         """测试按状态过滤场景列表"""
         result = self.resource.scene.list_scene({"status": "enabled"})
@@ -618,6 +669,28 @@ class TestSceneResource(TestCase):
         """测试场景详情"""
         result = self.resource.scene.retrieve_scene({"scene_id": self.scene.scene_id})
         self.assertEqual(result["name"], "主机安全审计")
+
+    def test_create_scene_validate_systems_schema(self):
+        """测试创建场景时 systems 子序列化器校验生效"""
+        with self.assertRaises(ValidateException):
+            self.resource.scene.create_scene(
+                {
+                    "name": "systems-校验",
+                    "managers": ["admin"],
+                    "systems": [{"is_all_systems": True}],
+                }
+            )
+
+    def test_create_scene_validate_tables_schema(self):
+        """测试创建场景时 tables 子序列化器校验生效"""
+        with self.assertRaises(ValidateException):
+            self.resource.scene.create_scene(
+                {
+                    "name": "tables-校验",
+                    "managers": ["admin"],
+                    "tables": [{"filter_rules": []}],
+                }
+            )
 
     def test_scene_retrieve_not_found(self):
         """测试场景不存在"""
@@ -670,6 +743,41 @@ class TestSceneResource(TestCase):
             result = self.resource.scene.get_scene_info({"scene_id": self.scene.scene_id})
             self.assertEqual(result["managers"], ["scene_admin"])
             self.assertEqual(result["users"], ["scene_user1", "scene_user2"])
+
+    def test_update_scene_validate_systems_schema(self):
+        """测试更新场景时 systems 子序列化器校验生效"""
+        with self.assertRaises(ValidateException):
+            self.resource.scene.update_scene(
+                {
+                    "scene_id": self.scene.scene_id,
+                    "systems": [{"is_all_systems": True}],
+                }
+            )
+
+    def test_update_scene_validate_tables_schema(self):
+        """测试更新场景时 tables 子序列化器校验生效"""
+        with self.assertRaises(ValidateException):
+            self.resource.scene.update_scene(
+                {
+                    "scene_id": self.scene.scene_id,
+                    "tables": [{"filter_rules": []}],
+                }
+            )
+
+    def test_delete_scene_ignores_deleted_strategy_binding(self):
+        """测试删除场景时会清理已删除策略的残留绑定"""
+        strategy = Strategy.objects.create(strategy_name="待删除策略")
+        binding = ResourceBinding.objects.create(
+            resource_type=ResourceVisibilityType.STRATEGY,
+            resource_id=str(strategy.strategy_id),
+            binding_type=BindingType.SCENE_BINDING,
+        )
+        ResourceBindingScene.objects.create(binding=binding, scene_id=self.scene.scene_id)
+        strategy.delete()
+
+        result = self.resource.scene.delete_scene({"scene_id": self.scene.scene_id})
+        self.assertEqual(result["message"], "success")
+        self.assertFalse(Scene.objects.filter(scene_id=self.scene.scene_id).exists())
 
     def test_scene_disable(self):
         """测试停用场景"""

--- a/src/backend/tests/test_strategy_v2/test_strategy.py
+++ b/src/backend/tests/test_strategy_v2/test_strategy.py
@@ -415,6 +415,29 @@ class StrategyTest(TestCase):
         self.assertGreaterEqual(len(s.risk_meta_field_config), 1)
         self.assertEqual(s.risk_meta_field_config[0]["field_name"], "risk_title")
 
+    @mock.patch("services.web.strategy_v2.resources.call_controller", mock.Mock(return_value=None))
+    def test_delete_strategy_cleans_scene_binding(self):
+        from services.web.scene.constants import ResourceVisibilityType
+        from services.web.scene.models import ResourceBinding
+
+        data = self._create_rule_strategy(name_suffix="delete_binding")
+        strategy_id = data["strategy_id"]
+        self.assertTrue(
+            ResourceBinding.objects.filter(
+                resource_type=ResourceVisibilityType.STRATEGY,
+                resource_id=str(strategy_id),
+            ).exists()
+        )
+
+        resource.strategy_v2.delete_strategy(strategy_id=strategy_id)
+
+        self.assertFalse(
+            ResourceBinding.objects.filter(
+                resource_type=ResourceVisibilityType.STRATEGY,
+                resource_id=str(strategy_id),
+            ).exists()
+        )
+
     @mock.patch("services.web.strategy_v2.resources.call_controller")
     def test_create_rule_strategy_with_manual_sql(self, mock_call_controller):
         mock_call_controller.return_value = None


### PR DESCRIPTION
## Summary
- 完善场景列表返回，补充 `system_count`、`table_count`、`strategy_ids`、`risk_count`
- 创建/更新场景接口补齐 `systems`、`tables` 的详细子序列化器校验
- 清理已删除策略残留的场景绑定，避免场景列表出现脏策略信息，也避免删除场景时被残留绑定误拦截

## Why
- 场景列表需要直接提供关联资源统计，避免前端再拼装数量
- 场景创建/更新请求需要对 `systems`、`tables` 子结构做显式校验，避免脏入参落库
- 策略为软删除，历史 `ResourceBinding` 残留会导致列表统计不准确，并阻塞场景删除

## Impact
- `scene list` 新增 `system_count`、`table_count`、`strategy_ids`、`risk_count`
- 已删除策略不会再出现在场景列表的 `strategy_ids` 中
- 删除策略会清理对应场景绑定；删除场景时会忽略已软删策略的残留绑定

## Root Cause
- 场景列表此前只返回基础信息，没有聚合场景下的系统、表、策略、风险统计
- `CreateSceneSerializer` / `UpdateSceneSerializer` 对嵌套结构缺少 typed serializer
- 策略软删除后，关联绑定没有同步清理，导致场景侧通过绑定表反查时读到脏数据

## Validation
- `pytest -q --reuse-db tests/test_strategy_v2/test_strategy.py -k 'delete_strategy_cleans_scene_binding'`
  - `2 passed`
- `pytest -q --reuse-db tests/test_scene/test_scene.py -k 'scene_list_contains_related_strategy_ids_and_risk_count or scene_list_contains_system_count_and_table_count or scene_list_ignores_deleted_strategy_binding or delete_scene_ignores_deleted_strategy_binding or create_scene_validate_systems_schema or create_scene_validate_tables_schema or update_scene_validate_systems_schema or update_scene_validate_tables_schema or test_scene_retrieve_with_iam_members or test_scene_info_get_with_iam_members'`
  - 本地测试库迁移阶段失败：`Duplicate column name 'iam_manager_group_id'`
  - 这是测试库状态问题，失败发生在建库/迁移阶段，不是本次改动触发的业务断言失败
