### PR TITLE
[codex] 修复风险报告模板渲染安全问题

### DIFF
--- a/src/backend/services/web/risk/report/renderer.py
+++ b/src/backend/services/web/risk/report/renderer.py
@@ -24,9 +24,10 @@ from typing import Any, Type
 
 from blueapps.core.celery import celery_app
 from blueapps.utils.logger import logger_celery
-from jinja2 import Environment, nodes
+from jinja2 import nodes
 from markupsafe import Markup
 
+from core.render import jinja2_environment
 from services.web.risk.report.markdown import render_ai_markdown
 from services.web.risk.report.providers import Provider
 
@@ -80,7 +81,7 @@ class TemplateParser:
         """
         self.template = template
         self.providers = providers
-        self.env = Environment()
+        self.env = jinja2_environment(autoescape=False)
         self.provider_calls: list[ProviderCall] = []
         self._processed_exprs: set[str] = set()  # 用于去重
 
@@ -306,7 +307,7 @@ def _render_template(template: str, providers: list[Provider], variables: dict[s
     # 1. 使用AST解析模板，提取所有Provider调用
     provider_calls = _parse_template(template, providers)
 
-    env = Environment()
+    env = jinja2_environment(autoescape=False)
 
     if not provider_calls:
         # 没有Provider调用，直接用Jinja2渲染普通变量

--- a/src/backend/services/web/risk/report/task_submitter.py
+++ b/src/backend/services/web/risk/report/task_submitter.py
@@ -46,7 +46,7 @@ def submit_render_task(
         Celery AsyncResult 对象
     """
     # 获取风险数据
-    risk_data = ReportRiskVariableSerializer(risk).data
+    risk_data = dict(ReportRiskVariableSerializer(risk).data)
 
     # 将 AIVariableConfig 转换为 dict 格式（AIProvider 需要）
     ai_variables_config = [

--- a/src/backend/tests/test_report/test_renderer.py
+++ b/src/backend/tests/test_report/test_renderer.py
@@ -436,6 +436,22 @@ class TestRenderTemplate(TestCase):
         self.assertIn("总金额：500000", result)
 
     @mock.patch("services.web.risk.report.providers.api.bk_base.query_sync")
+    def test_render_event_function_should_not_expose_python_globals(self, mock_query):
+        """事件聚合函数不应暴露 Python 函数对象内部属性"""
+        from services.web.risk.report.renderer import _render_template
+
+        mock_query.side_effect = mock_bkbase_query(MOCK_EVENTS)
+
+        template = "{{ count(event.event_id) }} {{ count.__globals__.__builtins__.eval('6*7') }}"
+        result = _render_template(
+            template=template,
+            providers=[create_event_provider_with_mock_api()],
+            variables={},
+        )
+
+        self.assertNotIn("42", result)
+
+    @mock.patch("services.web.risk.report.providers.api.bk_base.query_sync")
     def test_render_full_template(self, mock_query):
         """测试渲染完整模板（包含普通变量、事件聚合、AI变量）"""
         from services.web.risk.report.providers import AIProvider

--- a/src/backend/tests/test_report/test_task_submitter.py
+++ b/src/backend/tests/test_report/test_task_submitter.py
@@ -179,6 +179,21 @@ class TestSubmitRenderTask(TestCase):
         self.assertEqual(risk_data["strategy_id"], self.strategy.strategy_id)
 
     @patch("services.web.risk.report.task_submitter.render_template")
+    def test_submit_render_task_passes_plain_risk_dict(self, mock_task):
+        """风险报告模板上下文只传递纯业务字段，不能携带 serializer 回链"""
+        from services.web.risk.report.task_submitter import submit_render_task
+
+        mock_task.delay.return_value = MagicMock()
+
+        report_config = ReportConfig(template="{{ risk.title }}", ai_variables=[])
+
+        submit_render_task(risk=self.risk, report_config=report_config)
+
+        risk_data = mock_task.delay.call_args[1]["variables"]["risk"]
+        self.assertIs(type(risk_data), dict)
+        self.assertFalse(hasattr(risk_data, "serializer"))
+
+    @patch("services.web.risk.report.task_submitter.render_template")
     def test_submit_render_task_enable_cache_default_false(self, mock_task):
         """测试 enable_cache 默认为 False（后台事件触发场景）"""
         from services.web.risk.report.task_submitter import submit_render_task


### PR DESCRIPTION
## 变更内容
- 风险报告模板解析和渲染切换为项目封装的 Jinja2 沙箱环境
- 风险报告变量上下文转为普通 dict，避免 DRF ReturnDict 暴露 serializer 回链
- 补充模板函数对象属性链和风险上下文 plain dict 的回归测试

## TAPD
- [修复风险报告模板渲染安全问题](https://tapd.woa.com/tapd_fe/69990729/story/detail/1069990729134804969) --story=134804969
- 状态：已实现

## 背景
风险报告模板由用户配置，普通 Jinja2 Environment 下可通过注入的函数对象属性链访问 Python 内部对象；DRF ReturnDict 还会携带 serializer 回链，可能绕回 ORM 对象。

## 验证
- env BKAPP_DEPLOY_SERVICE=web .venv/bin/python manage.py test tests.test_report.test_renderer tests.test_report.test_task_submitter
  - Ran 62 tests, OK
- .venv/bin/pre-commit run --config .pre-commit-config.yaml --files services/web/risk/report/renderer.py services/web/risk/report/task_submitter.py tests/test_report/test_renderer.py tests/test_report/test_task_submitter.py
  - pyupgrade / merge conflict check / black / isort / Flake8 Passed
