### PR TITLE
feat: 风险支持自然语言搜索和智能分析功能-回归问题修复 --story=135539199

### DIFF
--- a/src/backend/config/default.py
+++ b/src/backend/config/default.py
@@ -93,6 +93,9 @@ IS_USE_CELERY = True
 # CELERY 并发数，默认为 2，可以通过环境变量或者 Procfile 设置
 CELERYD_CONCURRENCY = os.getenv("BK_CELERYD_CONCURRENCY", 2)  # noqa
 
+# Celery 生产者 Broker 连接池上限（每个进程），避免 Web/Worker 大量进程打满 RabbitMQ 连接数
+BROKER_POOL_LIMIT = int(os.getenv("BKAPP_CELERY_BROKER_POOL_LIMIT", 3))
+
 # CELERY 配置，申明任务的文件路径，即包含有 @task 装饰器的函数文件
 CELERY_IMPORTS = ()
 

--- a/src/backend/services/web/risk/resources/analyse_report.py
+++ b/src/backend/services/web/risk/resources/analyse_report.py
@@ -40,6 +40,8 @@ from core.utils.page import paginate_data
 from services.web.risk.constants import AnalyseReportStatus, AnalyseReportType
 from services.web.risk.models import (
     AnalyseReport,
+    AnalyseReportErrorInfo,
+    AnalyseReportExtraInfo,
     AnalyseReportRisk,
     AnalyseReportScenario,
     Risk,
@@ -77,6 +79,23 @@ def _build_analyse_report_temp_title(scenario: AnalyseReportScenario | None) -> 
         title_prefix = str(AnalyseReportType.CUSTOM.label)
     timestamp = timezone.localtime().strftime("%Y%m%d%H%M%S")
     return f"{title_prefix}_{timestamp}"
+
+
+def _mark_analyse_report_submit_failed(report: AnalyseReport, exc: Exception) -> None:
+    ended_at = timezone.now()
+    report.status = AnalyseReportStatus.FAILED
+    report.title_generating = False
+    report.extra_info = AnalyseReportExtraInfo.build(
+        started_at=ended_at,
+        ended_at=ended_at,
+        error=AnalyseReportErrorInfo(
+            error_type=exc.__class__.__name__,
+            error_message=str(exc),
+            retry_count=0,
+            max_retries=0,
+        ),
+    ).model_dump(exclude_none=True)
+    report.save(update_fields=["status", "title_generating", "extra_info", "updated_at"])
 
 
 class AnalyseReportMeta(AuditMixinResource, abc.ABC):
@@ -137,7 +156,15 @@ class GenerateAnalyseReport(AnalyseReportMeta):
         )
 
         # 4. 提交 Celery 异步任务
-        task = generate_analyse_report.delay(report_id=report.report_id)
+        try:
+            task = generate_analyse_report.delay(report_id=report.report_id)
+        except Exception as exc:
+            _mark_analyse_report_submit_failed(report, exc)
+            logging.getLogger(__name__).exception(
+                "[GenerateAnalyseReport] Submit task failed report_id=%s",
+                report.report_id,
+            )
+            raise
 
         # 5. 更新 task_id
         report.task_id = task.id

--- a/src/backend/services/web/risk/serializers.py
+++ b/src/backend/services/web/risk/serializers.py
@@ -1913,6 +1913,7 @@ class ListAnalyseReportRiskResponseSerializer(serializers.Serializer):
         help_text=gettext_lazy("命中策略风险等级"),
         required=False,
         allow_blank=True,
+        allow_null=True,
         default="",
     )
     strategy_id = serializers.IntegerField(
@@ -1945,7 +1946,7 @@ class ListAnalyseReportRiskResponseSerializer(serializers.Serializer):
             instance = {
                 "risk_id": instance.risk_id,
                 "title": instance.title,
-                "risk_level": getattr(instance.strategy, "risk_level", ""),
+                "risk_level": getattr(instance.strategy, "risk_level", None),
                 "status": instance.status,
                 "event_time": instance.event_time,
                 "event_end_time": instance.event_end_time,

--- a/src/backend/tests/test_risk/test_analyse_report.py
+++ b/src/backend/tests/test_risk/test_analyse_report.py
@@ -248,6 +248,32 @@ class TestGenerateAnalyseReport(AnalyseReportTestBase):
         self.assertIsNone(report.scenario)
         self.assertEqual(report.custom_prompt, "分析张三在英雄联盟业务的资产转移行为")
 
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    def test_generate_report_marks_failed_when_submit_task_failed(self, mock_task):
+        """Celery任务投递失败时标记报告失败并记录原因"""
+        mock_task.delay.side_effect = RuntimeError("connection limit is reached")
+
+        with self.assertRaises(RuntimeError):
+            self.resource.risk.generate_analyse_report(
+                {
+                    "scenario_key": "",
+                    "report_type": AnalyseReportType.CUSTOM,
+                    "title": "投递失败报告",
+                    "target_risks_filter": {},
+                    "custom_prompt": "分析近期高危风险",
+                }
+            )
+
+        report = AnalyseReport.objects.get(title="投递失败报告")
+        self.assertEqual(report.status, AnalyseReportStatus.FAILED)
+        self.assertEqual(report.task_id, "")
+        self.assertFalse(report.title_generating)
+        self.assertEqual(report.extra_info["error"]["error_type"], "RuntimeError")
+        self.assertEqual(report.extra_info["error"]["error_message"], "connection limit is reached")
+        self.assertEqual(report.extra_info["error"]["retry_count"], 0)
+        self.assertEqual(report.extra_info["error"]["max_retries"], 0)
+        AnalyseReportExtraInfo.model_validate(report.extra_info)
+
     def test_generate_report_serializer_validation(self):
         """测试请求序列化器校验"""
         # 缺少必填字段
@@ -1476,6 +1502,39 @@ class TestListAnalyseReportRiskAPIGW(AnalyseReportTestBase):
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data["total"], 2)
+
+    def test_apigw_list_report_risks_allows_empty_risk_level(self):
+        """APIGW响应兼容旧策略风险等级为空的数据"""
+        self.strategy.risk_level = None
+        self.strategy.save(update_fields=["risk_level"])
+
+        result = self.request_apigw_resource()
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual({item["risk_level"] for item in result["results"]}, {None})
+
+    def test_apigw_list_report_risks_allows_nullable_base_fields(self):
+        """APIGW响应兼容旧风险基础字段为空的数据"""
+        self.strategy.risk_level = None
+        self.strategy.save(update_fields=["risk_level"])
+        self.risk1.title = None
+        self.risk1.event_end_time = None
+        self.risk1.operator = None
+        self.risk1.current_operator = None
+        self.risk1.risk_label = None
+        self.risk1.save(update_fields=["title", "event_end_time", "operator", "current_operator", "risk_label"])
+
+        result = self.request_apigw_resource({"risk_id": self.risk1.risk_id, "with_detail": True})
+
+        self.assertEqual(result["total"], 1)
+        risk_data = result["results"][0]
+        self.assertIsNone(risk_data["risk_level"])
+        self.assertIsNone(risk_data["title"])
+        self.assertIsNone(risk_data["event_end_time"])
+        self.assertIsNone(risk_data["operator"])
+        self.assertIsNone(risk_data["current_operator"])
+        self.assertIsNone(risk_data["risk_label"])
+        self.assertIn("detail", risk_data)
 
     @mock.patch("core.permissions.get_app_info")
     def test_apigw_viewset_paginates_before_returning_detail(self, mock_get_app_info):


### PR DESCRIPTION
- 限制 Celery Broker 生产者连接池并在分析报告任务投递失败时标记报告失败
- 兼容分析报告关联风险 APIGW 响应中的历史空字段数据
- 补充报告任务投递失败与关联风险空字段回归测试