### PR TITLE
feat: 风险支持自然语言搜索和智能分析功能-支持导出任务重试 --story=1069990729135574093

### DIFF
--- a/src/backend/config/default.py
+++ b/src/backend/config/default.py
@@ -94,7 +94,7 @@ IS_USE_CELERY = True
 CELERYD_CONCURRENCY = os.getenv("BK_CELERYD_CONCURRENCY", 2)  # noqa
 
 # Celery 生产者 Broker 连接池上限（每个进程），避免 Web/Worker 大量进程打满 RabbitMQ 连接数
-BROKER_POOL_LIMIT = int(os.getenv("BKAPP_CELERY_BROKER_POOL_LIMIT", 3))
+BROKER_POOL_LIMIT = int(os.getenv("BKAPP_CELERY_BROKER_POOL_LIMIT", 10))
 
 # CELERY 配置，申明任务的文件路径，即包含有 @task 装饰器的函数文件
 CELERY_IMPORTS = ()

--- a/src/backend/config/default.py
+++ b/src/backend/config/default.py
@@ -27,6 +27,7 @@ from client_throttler.constants import TimeDurationUnit
 from django.utils.translation import gettext_lazy
 from redis.client import Redis
 
+from core.observability import BKResourceAPIInstrumentor
 from core.utils.distutils import strtobool
 from core.utils.environ import get_env_or_raise
 
@@ -310,7 +311,7 @@ AUTH_BACKEND_DOMAIN = SESSION_COOKIE_DOMAIN
 ENABLE_OTEL_TRACE = strtobool(os.getenv("BKAPP_ENABLE_OTEL_TRACE", "False"))
 BK_APP_OTEL_INSTRUMENT_DB_API = strtobool(os.getenv("BKAPP_OTEL_INSTRUMENT_DB_API", "False"))
 BKAPP_OTEL_SERVICE_NAME = os.getenv("BKAPP_OTEL_SERVICE_NAME", "bk-audit")
-BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS = []
+BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS = [BKResourceAPIInstrumentor()]
 
 # TAM
 AEGIS_ID = os.getenv("BKAPP_AEGIS_ID")
@@ -545,6 +546,8 @@ ALERT_DATA_ID = int(os.getenv("BKAPP_ALERT_DATA_ID", 0))
 
 #  Alert Configuration
 ALERT_ACCESS_TOKEN = os.getenv("BKAPP_ALERT_ACCESS_TOKEN", "")
+
+MONITOR_METRIC_TASK_TIMEOUT = int(os.getenv("BKAPP_MONITOR_METRIC_TASK_TIMEOUT", 60))
 
 # 日志导出状态上报的数据ID
 LOG_EXPORT_STATUS_DATA_ID = int(os.getenv("BKAPP_LOG_EXPORT_STATUS_DATA_ID", 0))

--- a/src/backend/core/monitor.py
+++ b/src/backend/core/monitor.py
@@ -15,8 +15,9 @@ specific language governing permissions and limitations under the License.
 We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
+import logging
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from bk_resource import api
 from blueapps.core.celery import celery_app
@@ -24,7 +25,9 @@ from django.conf import settings
 
 from core.utils.service import get_service_name
 
-__all__ = ["Event"]
+__all__ = ["Event", "Metric", "report_event_to_bk_monitor", "report_metric_to_bk_monitor"]
+
+logger = logging.getLogger(__name__)
 
 
 class Event:
@@ -36,45 +39,73 @@ class Event:
     data_id: int = settings.ALERT_DATA_ID
     access_token: str = settings.ALERT_ACCESS_TOKEN
 
-    def __init__(self, target: str, context: Dict, extra: Optional[Dict] = None):
-        self.target = target
+    def __init__(
+        self,
+        target: str = "",
+        context: Optional[Dict] = None,
+        extra: Optional[Dict] = None,
+        records: Optional[List[Dict[str, Any]]] = None,
+    ):
         self.timestamp = int(time.time() * 1000)
+        event_records = (
+            records if records is not None else [{"target": target, "context": context or {}, "extra": extra}]
+        )
+        self.records = [self._build_record(record) for record in event_records]
 
-        # 构建维度
-        self.dimension = {field: str(context.get(field, "")) for field in self.labelnames}
-        self.dimension["job"] = get_service_name()
+        # 保留单条场景的常用属性，兼容既有测试和临时调试代码。
+        first_record = self.records[0] if self.records else {}
+        self.target = first_record.get("target", target)
+        self.dimension = first_record.get("dimension", {})
+        self.content = first_record.get("event", {}).get("content", self.documentation or self.name)
 
-        # 构建内容
+    def _build_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        target = record.get("target", "")
+        context = record.get("context") or {}
+        extra = record.get("extra")
+        timestamp = record.get("timestamp") or self.timestamp
+
+        # 事件维度只取子类声明的 labelnames，避免把任意 context 全量打进 BKM。
+        dimension = {field: str(context.get(field, "")) for field in self.labelnames}
+        dimension["job"] = get_service_name()
+
         if extra:
             detail = ", ".join(f"{k}={v}" for k, v in extra.items())
-            self.content = f"{self.documentation or self.name}: {detail}"
+            content = f"{self.documentation or self.name}: {detail}"
         else:
-            self.content = self.documentation or self.name
+            content = self.documentation or self.name
+
+        return {
+            "event_name": str(self.name),
+            "event": {"content": content},
+            "target": target,
+            "dimension": dimension,
+            "timestamp": timestamp,
+        }
 
     def to_json(self) -> Dict:
         return {
             "data_id": self.data_id,
             "access_token": self.access_token,
-            "data": [
-                {
-                    "event_name": str(self.name),
-                    "event": {"content": self.content},
-                    "target": self.target,
-                    "dimension": self.dimension,
-                    "timestamp": self.timestamp,
-                }
-            ],
+            "data": self.records,
         }
 
     def report(self):
         """同步上报监控事件。"""
 
-        return api.bk_monitor.report_event(self.to_json())
+        try:
+            return api.bk_monitor.report_event(self.to_json())
+        except Exception:  # NOCC:broad-except(监控上报失败不能影响业务流程)
+            logger.exception("[MonitorEvent] report failed event=%s", self.name)
+            return None
 
     def async_report(self):
         """异步上报监控事件，避免业务流程阻塞在监控 API 调用上。"""
 
-        return report_event_to_bk_monitor.delay(self.to_json())
+        try:
+            return report_event_to_bk_monitor.delay(self.to_json())
+        except Exception:  # NOCC:broad-except(监控任务投递失败不能影响业务流程)
+            logger.exception("[MonitorEvent] async report failed event=%s", self.name)
+            return None
 
 
 @celery_app.task(time_limit=settings.MONITOR_EVENT_TASK_TIMEOUT)
@@ -82,3 +113,99 @@ def report_event_to_bk_monitor(payload: Dict):
     """统一的监控事件异步上报任务。"""
 
     return api.bk_monitor.report_event(payload)
+
+
+class Metric:
+    """BKM 自定义指标记录封装。
+
+    调用方只需要关心 metrics 和低基数 dimension；data_id、access_token、target、
+    timestamp、job 这些 BKM 协议字段统一在这里补齐。单条记录直接传 metrics /
+    dimension；多条记录传 records，不需要调用方拼 BKM payload。
+    """
+
+    target: str = "bk_audit"
+
+    def __init__(
+        self,
+        metrics: Optional[Dict[str, int | float]] = None,
+        dimension: Optional[Dict[str, Any]] = None,
+        target: Optional[str] = None,
+        timestamp: Optional[int] = None,
+        records: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self.data_id = settings.LOG_EXPORT_STATUS_DATA_ID
+        self.access_token = settings.LOG_EXPORT_STATUS_ACCESS_TOKEN
+        self.timestamp = timestamp or int(time.time() * 1000)
+        metric_records = (
+            records
+            if records is not None
+            else [
+                {
+                    "metrics": metrics or {},
+                    "dimension": dimension or {},
+                    "target": target,
+                    "timestamp": self.timestamp,
+                }
+            ]
+        )
+        self.records = [self._build_record(record) for record in metric_records]
+
+        # 保留单条场景的常用属性，兼容既有测试和临时调试代码。
+        first_record = self.records[0] if self.records else {}
+        self.metrics = first_record.get("metrics", {})
+        self.target = first_record.get("target", target or self.target)
+        self.dimension = first_record.get("dimension", {})
+
+    def _build_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        dimension = {key: str(value) for key, value in (record.get("dimension") or {}).items() if value is not None}
+        dimension["job"] = get_service_name()
+        return {
+            "target": record.get("target") or self.target,
+            "metrics": record.get("metrics") or {},
+            "dimension": dimension,
+            "timestamp": record.get("timestamp") or self.timestamp,
+        }
+
+    @property
+    def metric_names(self) -> List[str]:
+        return sorted({name for record in self.records for name in record.get("metrics", {})})
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.data_id and self.access_token)
+
+    def to_json(self) -> Dict:
+        return {
+            "data_id": self.data_id,
+            "access_token": self.access_token,
+            "data": self.records,
+        }
+
+    def report(self):
+        """同步上报监控指标。"""
+
+        if not self.is_configured:
+            return None
+        try:
+            return api.bk_monitor.report_metric(self.to_json())
+        except Exception:  # NOCC:broad-except(监控上报失败不能影响业务流程)
+            logger.exception("[MonitorMetric] report failed metrics=%s", self.metric_names)
+            return None
+
+    def async_report(self):
+        """异步上报监控指标，避免业务流程阻塞在监控 API 调用上。"""
+
+        if not self.is_configured:
+            return None
+        try:
+            return report_metric_to_bk_monitor.delay(self.to_json())
+        except Exception:  # NOCC:broad-except(监控任务投递失败不能影响业务流程)
+            logger.exception("[MonitorMetric] async report failed metrics=%s", self.metric_names)
+            return None
+
+
+@celery_app.task(time_limit=settings.MONITOR_METRIC_TASK_TIMEOUT)
+def report_metric_to_bk_monitor(payload: Dict):
+    """统一的监控指标异步上报任务。"""
+
+    return api.bk_monitor.report_metric(payload)

--- a/src/backend/core/observability.py
+++ b/src/backend/core/observability.py
@@ -12,6 +12,16 @@ Celery、requests、Redis 等框架级 span 会自动生成。本文件只补自
    - `start_observation_span`：给关键业务入口或阶段手动创建 business span。
    - span 只描述调用链，不负责推断业务成功率。
 
+   `BKResourceAPIInstrumentor` 的设计点：
+   - 包 `APIResource.__call__`：`ResourceRequestLog` 在 `Resource.__call__`
+     的 finally 中打印，span 必须覆盖到 finally，日志才有 trace_id。
+   - 包 `APIResource.request`：直接 `.request()` 不经过 `__call__`，仍要有
+     client span。
+   - 包 `bk_resource` 的 `ThreadPool`：`bulk_request` 在线程池里调用 request，
+     OTel context 默认不跨线程传播，因此在 SDK 线程池任务入口统一恢复 context。
+   - `__call__` 内部本来会调用一次 `.request()`；这次 request span 会被跳过，
+     避免同一个 API 调用生成两个同名 client span。
+
 2. Metric
    - `report_observation_metric`：基于 `core.monitor.Metric` 显式上报低基数业务指标。
    - 调用方必须传入真实业务 status，例如 NL2Risk 的 parse_failed 虽然不抛异常，
@@ -25,10 +35,13 @@ Celery、requests、Redis 等框架级 span 会自动生成。本文件只补自
 """
 
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from functools import wraps
-from typing import Any, Collection, Generator
+from contextvars import ContextVar
+from functools import partial, wraps
+from typing import Any, Callable, Collection, Generator
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode
@@ -39,8 +52,14 @@ BUSINESS_SPAN_INSTRUMENTATION_NAME = "bk_audit.business"
 API_SPAN_STATUS_SUCCESS = "success"
 API_SPAN_STATUS_ERROR = "error"
 
+# 对外使用的指标状态值。值必须保持低基数且稳定，便于 BKM 过滤和聚合。
 OBSERVATION_METRIC_STATUS_SUCCESS = "success"
 OBSERVATION_METRIC_STATUS_ERROR = "error"
+
+_SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG: ContextVar[tuple[str, ...]] = ContextVar(
+    "bk_audit_skip_next_api_resource_request_span_for_call_log",
+    default=(),
+)
 
 
 def _to_span_attribute_value(value: Any) -> Any:
@@ -59,8 +78,28 @@ def _set_span_attribute(span: Span, key: str, value: Any):
     span.set_attribute(key, _to_span_attribute_value(value))
 
 
-def set_span_attributes(span: Span, attributes: dict[str, Any] | None):
-    """批量补充 span attribute，供业务代码在拿到中间结果后继续补信息。"""
+def set_span_attributes(span: Span, attributes: dict[str, Any] | None) -> None:
+    """给已有 span 批量补充业务属性。
+
+    适用于 span 已经创建，但关键维度要等中间结果返回后才能确定的场景，
+    例如 DB 查询完成后补数量，或 AI API 返回后补内容大小。
+
+    参数：
+        span: `start_observation_span()` 返回的 span，或
+            `trace.get_current_span()` 获取到的当前 span。
+        attributes: 需要写入 span 的属性字典。值为 None 的属性会被忽略；
+            非标量值会先转成字符串，再交给 OTel。
+
+    返回：
+        None。
+
+    示例：
+        ```python
+        with start_observation_span("risk.export") as span:
+            export_file = build_export_file()
+            set_span_attributes(span, {"bk_audit.export.total": export_file.total})
+        ```
+    """
 
     if not attributes or not span.is_recording():
         return
@@ -69,11 +108,110 @@ def set_span_attributes(span: Span, attributes: dict[str, Any] | None):
         _set_span_attribute(span, key, value)
 
 
+def _get_current_observation_context():
+    """截取当前 OTel context，供线程池任务提交时携带。"""
+
+    return otel_context.get_current()
+
+
+def _run_with_observation_context(parent_context: Any, callback: Callable[[], Any]):
+    """在线程池子线程中恢复提交任务时的 OTel context，再执行回调。"""
+
+    context_token = otel_context.attach(parent_context)
+    try:
+        return callback()
+    finally:
+        otel_context.detach(context_token)
+
+
+def submit_with_observation_context(
+    executor: ThreadPoolExecutor,
+    callback: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Future:
+    """提交线程池任务，并让子线程继承当前 OTel context。
+
+    OTel 使用的 `contextvars` 默认不会自动传播到新线程。如果子线程里会打日志、
+    创建 span，或调用 `bk_resource.api`，需要用这个 helper 替代
+    `executor.submit(...)`。
+
+    参数：
+        executor: 执行任务的 `concurrent.futures.ThreadPoolExecutor`。
+        callback: 在线程池 worker 中执行的回调函数。
+        *args: 传给 `callback` 的位置参数。
+        **kwargs: 传给 `callback` 的关键字参数。
+
+    返回：
+        `executor.submit` 返回的 `Future` 对象。
+
+    示例：
+        ```python
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            future = submit_with_observation_context(executor, api_call, payload)
+            result = future.result()
+        ```
+    """
+
+    task = partial(callback, *args, **kwargs)
+    return executor.submit(_run_with_observation_context, _get_current_observation_context(), task)
+
+
 def _get_api_resource_span_name(resource: Any) -> str:
     """生成低基数 client span 名称，避免 URL、参数进入 span name。"""
 
     module_name = getattr(resource, "module_name", "") or resource.__class__.__module__
     return f"api.{module_name}.{resource.__class__.__name__}"
+
+
+def _run_with_next_request_span_skipped(span_name: str, callback: Callable[[], Any]):
+    """标记 `__call__` 即将触发的下一次同名 `.request()` 不再重复建 span。"""
+
+    skip_span_names = _SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.get()
+    token = _SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.set((*skip_span_names, span_name))
+    try:
+        return callback()
+    finally:
+        _SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.reset(token)
+
+
+def _run_api_resource_request_with_span(resource: Any, callback: Callable[[], Any]):
+    """直接 `.request()` 建 span；若来自 `__call__`，只跳过被标记的那一次。"""
+
+    span_name = _get_api_resource_span_name(resource)
+    skip_span_names = list(_SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.get())
+    if span_name not in skip_span_names:
+        return _run_with_api_resource_span(resource, callback)
+
+    skip_span_names.remove(span_name)
+    token = _SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.set(tuple(skip_span_names))
+    try:
+        return callback()
+    finally:
+        _SKIP_NEXT_REQUEST_SPAN_NAMES_FOR_CALL_LOG.reset(token)
+
+
+def _run_with_api_resource_span(resource: Any, callback: Callable[[], Any]):
+    """在稳定的 APIResource client span 中执行回调。"""
+
+    span_name = _get_api_resource_span_name(resource)
+
+    tracer = trace.get_tracer(API_SPAN_INSTRUMENTATION_NAME)
+    with tracer.start_as_current_span(
+        span_name,
+        kind=SpanKind.CLIENT,
+        record_exception=True,
+        set_status_on_exception=True,
+    ) as span:
+        _set_api_resource_attributes(span, resource, API_SPAN_STATUS_SUCCESS)
+        try:
+            result = callback()
+        except Exception as err:
+            _set_api_resource_attributes(span, resource, API_SPAN_STATUS_ERROR)
+            _set_api_resource_error_attributes(span, err)
+            raise
+        span.set_status(Status(StatusCode.OK))
+        return result
 
 
 def _set_api_resource_attributes(span: Span, resource: Any, status: str):
@@ -109,11 +247,42 @@ def report_observation_metric(
     dimensions: dict[str, Any] | None = None,
     error_type: str = "",
 ):
-    """
-    显式上报一次业务调用的聚合指标。
+    """把一次业务调用上报为 BKM 自定义指标。
 
-    这里不从 span status 推断成功失败，因为 span 只能说明代码是否抛异常；
-    业务失败可能以返回值表达，例如 NL2Risk 解析失败。
+    这里不会从 span status 推断业务成功或失败。部分业务失败不会抛异常，
+    而是通过返回值表达，例如 NL2Risk 解析失败。
+
+    参数：
+        name: 稳定、低基数的操作名。会写入 `span_name` 维度，便于仪表盘过滤，
+            例如
+            `risk.nl2risk_filter.generate`.
+        started_at: 操作开始前记录的 `time.perf_counter()` 值。本函数会转换成
+            `duration_ms`。
+        status: 业务状态。优先使用 `OBSERVATION_METRIC_STATUS_SUCCESS` 或
+            `OBSERVATION_METRIC_STATUS_ERROR`.
+        dimensions: 额外低基数维度，例如 `service`、`operation`、`scenario` 或
+            `queue`。
+        error_type: 低基数错误类型。成功时保持为空字符串。
+
+    返回：
+        `Metric.async_report()` 返回的 Celery async result；如果未配置指标上报，
+        或任务投递失败，则返回 None。
+
+    示例：
+        ```python
+        started_at = time.perf_counter()
+        try:
+            result = parse_query(query)
+        except ValueError:
+            report_observation_metric(
+                name="risk.nl2risk_filter.generate",
+                started_at=started_at,
+                status=OBSERVATION_METRIC_STATUS_ERROR,
+                dimensions={"service": "risk", "operation": "nl2risk_filter"},
+                error_type="ValueError",
+            )
+            raise
+        ```
     """
 
     duration_ms = max(0, int((time.perf_counter() - started_at) * 1000))
@@ -142,7 +311,32 @@ def start_observation_span(
     attributes: dict[str, Any] | None = None,
     kind: SpanKind = SpanKind.INTERNAL,
 ) -> Generator[Span, None, None]:
-    """创建一个手动业务 span；metric 请由业务代码显式调用。"""
+    """创建一个手动业务 span。
+
+    适用于 Django、Celery、requests、Redis、`bk_resource` 自动埋点覆盖不到的
+    关键业务阶段。本函数只负责 trace，不会自动上报 metric；业务成功或失败状态
+    明确后，需要显式调用 `report_observation_metric()`。
+
+    参数：
+        name: 稳定、低基数的 span 名称，例如
+            `risk.generate_analyse_report.render`.
+        attributes: 初始 span 属性。值应保持低基数，并适合在 APM 中过滤。
+        kind: OTel span kind。业务阶段默认使用 `SpanKind.INTERNAL`；
+            只有在表达真实边界时才使用其他类型。
+
+    产出：
+        创建好的 `Span`。调用方可以在拿到中间结果后继续补充属性。
+
+    示例：
+        ```python
+        with start_observation_span(
+            "risk.generate_analyse_report.render",
+            {"bk_audit.report.id": report_id},
+        ) as span:
+            content = render_report(report_id)
+            set_span_attributes(span, {"bk_audit.report.content_size": len(content)})
+        ```
+    """
 
     tracer = trace.get_tracer(BUSINESS_SPAN_INSTRUMENTATION_NAME)
     with tracer.start_as_current_span(
@@ -163,9 +357,34 @@ def start_observation_span(
 
 
 class BKResourceAPIInstrumentor(BaseInstrumentor):
-    """为 bk_resource 的 APIResource.perform_request 补 client span。"""
+    """为 `bk_resource` API 调用补充稳定的 client span。
 
-    _original_perform_request = None
+    该 instrumentor 通过 Django settings 中的
+    `BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS` 注册，业务代码不应直接调用。
+    它会 patch `APIResource.__call__`、`APIResource.request` 和 SDK
+    `ThreadPool` 包装函数，用于覆盖：
+
+    - `Resource.__call__` 内部的 `ResourceRequestLog.record()`。
+    - 绕过 `__call__` 的直接 `.request()` 调用。
+    - 可能丢失 OTel context 的 `bulk_request()` worker 子线程。
+
+    参数：
+        不需要构造参数。
+
+    返回：
+        遵循 OpenTelemetry `BaseInstrumentor` 约定。`instrument()`、
+        `uninstrument()` 等生命周期方法由父类提供。
+
+    示例：
+        ```python
+        BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS = [BKResourceAPIInstrumentor()]
+        ```
+    """
+
+    _original_call = None
+    _original_request = None
+    _original_thread_pool_get_func_with_local = None
+    _had_own_call = False
     _is_patched = False
 
     def instrumentation_dependencies(self) -> Collection[str]:
@@ -178,31 +397,57 @@ class BKResourceAPIInstrumentor(BaseInstrumentor):
         # config.default 会在 Django settings 初始化期间导入本模块；bk_resource 顶层导入会读取
         # settings.APP_CODE，因此只能在真正执行 instrument 时延迟导入。
         from bk_resource.contrib.api import APIResource
+        from bk_resource.utils.thread_backend import ThreadPool
 
-        original_perform_request = APIResource.perform_request
+        original_call = APIResource.__call__
+        original_request = APIResource.request
+        original_thread_pool_get_func_with_local = ThreadPool.get_func_with_local
 
-        @wraps(original_perform_request)
-        def traced_perform_request(resource, validated_request_data):
-            tracer = trace.get_tracer(API_SPAN_INSTRUMENTATION_NAME)
+        @wraps(original_call)
+        def traced_call(resource, *args, **kwargs):
+            # `Resource.__call__` 的 finally 会打印 ResourceRequestLog；
+            # span 放在这里才能让日志带 trace_id。
             span_name = _get_api_resource_span_name(resource)
-            with tracer.start_as_current_span(
-                span_name,
-                kind=SpanKind.CLIENT,
-                record_exception=True,
-                set_status_on_exception=True,
-            ) as span:
-                _set_api_resource_attributes(span, resource, API_SPAN_STATUS_SUCCESS)
-                try:
-                    result = original_perform_request(resource, validated_request_data)
-                except Exception as err:
-                    _set_api_resource_attributes(span, resource, API_SPAN_STATUS_ERROR)
-                    _set_api_resource_error_attributes(span, err)
-                    raise
-                span.set_status(Status(StatusCode.OK))
-                return result
 
-        self.__class__._original_perform_request = original_perform_request
-        APIResource.perform_request = traced_perform_request
+            def call_original():
+                return _run_with_next_request_span_skipped(
+                    span_name,
+                    lambda: original_call(resource, *args, **kwargs),
+                )
+
+            return _run_with_api_resource_span(resource, call_original)
+
+        @wraps(original_request)
+        def traced_request(resource, request_data=None, **kwargs):
+            # 直接 `.request()` 和 `bulk_request()` 子请求不会经过 `__call__`，这里单独兜住。
+            return _run_api_resource_request_with_span(
+                resource,
+                lambda: original_request(resource, request_data=request_data, **kwargs),
+            )
+
+        @wraps(original_thread_pool_get_func_with_local)
+        def traced_get_func_with_local(func):
+            # bk_resource 的 bulk_request 统一走 ThreadPool；
+            # 在任务封装点继承 context，比复制每个 bulk_request 实现更稳。
+            parent_context = _get_current_observation_context()
+            local_func = original_thread_pool_get_func_with_local(func)
+
+            @wraps(func)
+            def func_with_context(*args, **kwargs):
+                return _run_with_observation_context(
+                    parent_context,
+                    lambda: local_func(*args, **kwargs),
+                )
+
+            return func_with_context
+
+        self.__class__._original_call = original_call
+        self.__class__._original_request = original_request
+        self.__class__._original_thread_pool_get_func_with_local = original_thread_pool_get_func_with_local
+        self.__class__._had_own_call = "__call__" in APIResource.__dict__
+        APIResource.__call__ = traced_call
+        APIResource.request = traced_request
+        ThreadPool.get_func_with_local = staticmethod(traced_get_func_with_local)
         self.__class__._is_patched = True
 
     def _uninstrument(self, **kwargs):
@@ -210,9 +455,18 @@ class BKResourceAPIInstrumentor(BaseInstrumentor):
             return
 
         from bk_resource.contrib.api import APIResource
+        from bk_resource.utils.thread_backend import ThreadPool
 
-        APIResource.perform_request = self.__class__._original_perform_request
-        self.__class__._original_perform_request = None
+        if self.__class__._had_own_call:
+            APIResource.__call__ = self.__class__._original_call
+        else:
+            delattr(APIResource, "__call__")
+        APIResource.request = self.__class__._original_request
+        ThreadPool.get_func_with_local = staticmethod(self.__class__._original_thread_pool_get_func_with_local)
+        self.__class__._original_call = None
+        self.__class__._original_request = None
+        self.__class__._original_thread_pool_get_func_with_local = None
+        self.__class__._had_own_call = False
         self.__class__._is_patched = False
 
 
@@ -223,4 +477,5 @@ __all__ = [
     "report_observation_metric",
     "set_span_attributes",
     "start_observation_span",
+    "submit_with_observation_context",
 ]

--- a/src/backend/core/observability.py
+++ b/src/backend/core/observability.py
@@ -1,0 +1,226 @@
+"""
+审计中心业务观测性补充入口。
+
+项目的 OTel 初始化由 `blueapps.opentelemetry.instrument_app` 完成，Django、
+Celery、requests、Redis 等框架级 span 会自动生成。本文件只补自动埋点
+覆盖不到、但排障时必须稳定可查的业务语义。
+
+职责边界：
+1. Trace / Span
+   - `BKResourceAPIInstrumentor`：把 bk_resource 的三方 API 调用包成
+     `api.<module>.<Resource>` 形式的 client span。
+   - `start_observation_span`：给关键业务入口或阶段手动创建 business span。
+   - span 只描述调用链，不负责推断业务成功率。
+
+2. Metric
+   - `report_observation_metric`：基于 `core.monitor.Metric` 显式上报低基数业务指标。
+   - 调用方必须传入真实业务 status，例如 NL2Risk 的 parse_failed 虽然不抛异常，
+     也应由业务代码显式计入错误率。
+   - 当前按接入约定复用 `LOG_EXPORT_STATUS_DATA_ID/ACCESS_TOKEN`；虽然配置名带
+     log export，但这里把它作为通用 BKM 自定义指标数据源使用。
+
+3. Event
+   - 失败事件仍放在 `core.monitor.Event` 及其业务子类中。
+   - Event 面向“少量、可读、需要人处理”的异常事实；Metric 面向聚合告警。
+"""
+
+import time
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Collection, Generator
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+API_SPAN_INSTRUMENTATION_NAME = "bk_audit.bk_resource"
+BUSINESS_SPAN_INSTRUMENTATION_NAME = "bk_audit.business"
+
+API_SPAN_STATUS_SUCCESS = "success"
+API_SPAN_STATUS_ERROR = "error"
+
+OBSERVATION_METRIC_STATUS_SUCCESS = "success"
+OBSERVATION_METRIC_STATUS_ERROR = "error"
+
+
+def _to_span_attribute_value(value: Any) -> Any:
+    """把项目内常见值收敛成 OTel attribute 支持的稳定标量。"""
+
+    if isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value) if value is not None else ""
+
+
+def _set_span_attribute(span: Span, key: str, value: Any):
+    """安全设置单个 span attribute；None 表示没有该维度，直接跳过。"""
+
+    if value is None:
+        return
+    span.set_attribute(key, _to_span_attribute_value(value))
+
+
+def set_span_attributes(span: Span, attributes: dict[str, Any] | None):
+    """批量补充 span attribute，供业务代码在拿到中间结果后继续补信息。"""
+
+    if not attributes or not span.is_recording():
+        return
+
+    for key, value in attributes.items():
+        _set_span_attribute(span, key, value)
+
+
+def _get_api_resource_span_name(resource: Any) -> str:
+    """生成低基数 client span 名称，避免 URL、参数进入 span name。"""
+
+    module_name = getattr(resource, "module_name", "") or resource.__class__.__module__
+    return f"api.{module_name}.{resource.__class__.__name__}"
+
+
+def _set_api_resource_attributes(span: Span, resource: Any, status: str):
+    """写入 bk_resource client span 的稳定业务维度。"""
+
+    if not span.is_recording():
+        return
+
+    _set_span_attribute(span, "bk_audit.api.module", getattr(resource, "module_name", ""))
+    _set_span_attribute(span, "bk_audit.api.resource", resource.__class__.__name__)
+    _set_span_attribute(span, "bk_audit.api.method", getattr(resource, "method", ""))
+    _set_span_attribute(span, "bk_audit.api.action", getattr(resource, "action", ""))
+    _set_span_attribute(span, "bk_audit.api.status", status)
+
+
+def _set_api_resource_error_attributes(span: Span, err: Exception):
+    """把三方 API 异常类型和状态码写到 client span 上。"""
+
+    if not span.is_recording():
+        return
+
+    _set_span_attribute(span, "bk_audit.api.error_type", err.__class__.__name__)
+    status_code = getattr(err, "status_code", None)
+    if status_code:
+        _set_span_attribute(span, "bk_audit.api.status_code", status_code)
+    span.set_status(Status(StatusCode.ERROR, str(err)[:1024]))
+
+
+def report_observation_metric(
+    name: str,
+    started_at: float,
+    status: str,
+    dimensions: dict[str, Any] | None = None,
+    error_type: str = "",
+):
+    """
+    显式上报一次业务调用的聚合指标。
+
+    这里不从 span status 推断成功失败，因为 span 只能说明代码是否抛异常；
+    业务失败可能以返回值表达，例如 NL2Risk 解析失败。
+    """
+
+    duration_ms = max(0, int((time.perf_counter() - started_at) * 1000))
+    metric_dimensions = {
+        **(dimensions or {}),
+        "span_name": name,
+        "status": status,
+        "error_type": error_type,
+    }
+
+    # 延迟导入：config.default 会在 settings 初始化期间导入本模块，不能提前加载 bk_resource。
+    from core.monitor import Metric
+
+    return Metric(
+        metrics={
+            "call_count": 1,
+            "duration_ms": duration_ms,
+        },
+        dimension=metric_dimensions,
+    ).async_report()
+
+
+@contextmanager
+def start_observation_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+    kind: SpanKind = SpanKind.INTERNAL,
+) -> Generator[Span, None, None]:
+    """创建一个手动业务 span；metric 请由业务代码显式调用。"""
+
+    tracer = trace.get_tracer(BUSINESS_SPAN_INSTRUMENTATION_NAME)
+    with tracer.start_as_current_span(
+        name,
+        kind=kind,
+        record_exception=True,
+        set_status_on_exception=True,
+    ) as span:
+        set_span_attributes(span, attributes)
+        try:
+            yield span
+        except Exception as err:
+            # OTel 会记录异常栈；这里补一个低基数 error_type，便于 APM 侧聚合过滤。
+            _set_span_attribute(span, "bk_audit.error_type", err.__class__.__name__)
+            span.set_status(Status(StatusCode.ERROR, str(err)[:1024]))
+            raise
+        span.set_status(Status(StatusCode.OK))
+
+
+class BKResourceAPIInstrumentor(BaseInstrumentor):
+    """为 bk_resource 的 APIResource.perform_request 补 client span。"""
+
+    _original_perform_request = None
+    _is_patched = False
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return []
+
+    def _instrument(self, **kwargs):
+        if self.__class__._is_patched:
+            return
+
+        # config.default 会在 Django settings 初始化期间导入本模块；bk_resource 顶层导入会读取
+        # settings.APP_CODE，因此只能在真正执行 instrument 时延迟导入。
+        from bk_resource.contrib.api import APIResource
+
+        original_perform_request = APIResource.perform_request
+
+        @wraps(original_perform_request)
+        def traced_perform_request(resource, validated_request_data):
+            tracer = trace.get_tracer(API_SPAN_INSTRUMENTATION_NAME)
+            span_name = _get_api_resource_span_name(resource)
+            with tracer.start_as_current_span(
+                span_name,
+                kind=SpanKind.CLIENT,
+                record_exception=True,
+                set_status_on_exception=True,
+            ) as span:
+                _set_api_resource_attributes(span, resource, API_SPAN_STATUS_SUCCESS)
+                try:
+                    result = original_perform_request(resource, validated_request_data)
+                except Exception as err:
+                    _set_api_resource_attributes(span, resource, API_SPAN_STATUS_ERROR)
+                    _set_api_resource_error_attributes(span, err)
+                    raise
+                span.set_status(Status(StatusCode.OK))
+                return result
+
+        self.__class__._original_perform_request = original_perform_request
+        APIResource.perform_request = traced_perform_request
+        self.__class__._is_patched = True
+
+    def _uninstrument(self, **kwargs):
+        if not self.__class__._is_patched:
+            return
+
+        from bk_resource.contrib.api import APIResource
+
+        APIResource.perform_request = self.__class__._original_perform_request
+        self.__class__._original_perform_request = None
+        self.__class__._is_patched = False
+
+
+__all__ = [
+    "OBSERVATION_METRIC_STATUS_ERROR",
+    "OBSERVATION_METRIC_STATUS_SUCCESS",
+    "BKResourceAPIInstrumentor",
+    "report_observation_metric",
+    "set_span_attributes",
+    "start_observation_span",
+]

--- a/src/backend/services/web/common/monitor.py
+++ b/src/backend/services/web/common/monitor.py
@@ -23,6 +23,8 @@ __all__ = [
     "RiskReportRenderFailedEvent",
     "RiskReportContentQualityEvent",
     "RiskExportFailedEvent",
+    "NL2RiskFilterFailedEvent",
+    "AnalyseReportGenerateFailedEvent",
 ]
 
 
@@ -64,3 +66,19 @@ class RiskExportFailedEvent(Event):
     name = "risk_export_failed"
     documentation = "风险异步导出失败"
     labelnames = ["username", "risk_count"]
+
+
+class NL2RiskFilterFailedEvent(Event):
+    """自然语言转风险筛选条件失败事件"""
+
+    name = "nl2risk_filter_failed"
+    documentation = "自然语言转风险筛选条件失败"
+    labelnames = ["status", "scope_type", "error_type"]
+
+
+class AnalyseReportGenerateFailedEvent(Event):
+    """AI 分析报告最终生成失败事件"""
+
+    name = "analyse_report_generate_failed"
+    documentation = "AI 分析报告最终生成失败"
+    labelnames = ["report_type", "has_scenario", "error_type"]

--- a/src/backend/services/web/databus/collector/snapshot/join/base.py
+++ b/src/backend/services/web/databus/collector/snapshot/join/base.py
@@ -200,12 +200,9 @@ class BaseJoinDataHandler(metaclass=abc.ABCMeta):
             self.storage_type,
             snapshot=self.snapshot,
         )
-        # 已有清洗链路则更新
+        # 已有清洗链路不做调整
         if self._get_table_id():
-            logger.info(f"{self.__class__.__name__} Update Etl; SnapshotID => {self.snapshot.id}")
-            self.snapshot.bkbase_processing_id, self.snapshot.bkbase_table_id = etl_storage_handler.create_clean(
-                update=True
-            )
+            logger.info(f"{self.__class__.__name__} Skip Etl; SnapshotID => {self.snapshot.id}")
         else:
             # 没有清洗链路则创建
             logger.info(f"{self.__class__.__name__} Create Etl; SnapshotID => {self.snapshot.id}")
@@ -224,9 +221,9 @@ class BaseJoinDataHandler(metaclass=abc.ABCMeta):
         storage = self.snapshot.storages.filter(storage_type=self.storage_type).first()
         try:
             if storage.status == SnapshotRunningStatus.RUNNING:
-                logger.info(f"{self.__class__.__name__} update Storage; SnapshotID => {self.snapshot.id}")
-                etl_storage_handler.create_storage(update=True)
-            elif storage.status == SnapshotRunningStatus.FAILED:
+                logger.info(f"{self.__class__.__name__} Skip Storage; SnapshotID => {self.snapshot.id}")
+                return
+            if storage.status == SnapshotRunningStatus.FAILED:
                 etl_storage_handler.create_storage(update=True)
             else:
                 etl_storage_handler.create_storage()

--- a/src/backend/services/web/databus/management/commands/update_asset_etl.py
+++ b/src/backend/services/web/databus/management/commands/update_asset_etl.py
@@ -16,7 +16,9 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
-from django.core.management.base import BaseCommand
+import json
+
+from django.core.management.base import BaseCommand, CommandError
 
 from apps.meta.models import ResourceType, System
 from services.web.databus.collector.snapshot.join.etl_storage import (
@@ -31,14 +33,32 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--system-id", required=True, help="系统ID")
         parser.add_argument("--resource-type-id", required=True, help="资源类型ID")
+        parser.add_argument("--custom-config", help="写入 Snapshot.custom_config 的 JSON 对象")
+
+    def parse_custom_config(self, raw_config: str | None) -> dict | None:
+        if raw_config is None:
+            return None
+        try:
+            custom_config = json.loads(raw_config)
+        except json.JSONDecodeError as err:
+            raise CommandError(f"--custom-config must be valid JSON: {err}") from err
+        if not isinstance(custom_config, dict):
+            raise CommandError("--custom-config must be a JSON object")
+        return custom_config
 
     def handle(self, *args, **kwargs):
         system_id = kwargs["system_id"]
         resource_type_id = kwargs["resource_type_id"]
+        custom_config = self.parse_custom_config(kwargs.get("custom_config"))
 
         snapshot = Snapshot.objects.get(system_id=system_id, resource_type_id=resource_type_id)
         system = System.objects.get(system_id=system_id)
         resource_type = ResourceType.objects.get(system_id=system_id, resource_type_id=resource_type_id)
+
+        if custom_config is not None:
+            snapshot.custom_config = custom_config
+            snapshot.save(update_fields=["custom_config"])
+            self.stdout.write("[update_asset_etl] 自定义配置已更新")
 
         self.stdout.write(
             f"[update_asset_etl] SystemID => {system_id}, ResourceTypeID => {resource_type_id}, "

--- a/src/backend/services/web/risk/report/analyse_report.py
+++ b/src/backend/services/web/risk/report/analyse_report.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - 审计中心 (BlueKing - Audit Center) available.
+Copyright (C) 2023 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from blueapps.utils.logger import logger_celery
+from django.conf import settings
+
+from services.web.risk.models import AnalyseReport, AnalyseReportRisk
+from services.web.risk.serializers import ListRiskRequestSerializer
+
+
+def load_analyse_report_risk_ids(report: AnalyseReport, risk_limit: int) -> list[str]:
+    """复用 ListRisk 的参数校验、权限过滤和检索分支，按报告创建人加载最终风险 ID。"""
+    from services.web.risk.resources.risk import ListRisk
+
+    list_risk = ListRisk()
+    serializer = ListRiskRequestSerializer(data=report.prompt_params or {})
+    serializer.is_valid(raise_exception=True)
+    return list_risk.load_filter_risk_ids(
+        dict(serializer.validated_data),
+        username=report.created_by,
+        risk_limit=risk_limit,
+    )
+
+
+def bind_risks_to_analyse_report(report: AnalyseReport) -> int:
+    """
+    根据报告 prompt_params 创建报告风险快照。
+
+    返回本次快照命中的风险数量。重复调用不会创建重复关联。
+    """
+    if not report.created_by:
+        logger_celery.warning("[BindRisksToAnalyseReport] Skip report without creator, report_id=%s", report.report_id)
+        return 0
+
+    risk_limit = int(getattr(settings, "ANALYSE_REPORT_RISK_LIMIT", 100))
+    if risk_limit <= 0:
+        logger_celery.info(
+            "[BindRisksToAnalyseReport] Skip because risk limit is %s, report_id=%s",
+            risk_limit,
+            report.report_id,
+        )
+        return 0
+
+    risk_ids = load_analyse_report_risk_ids(report, risk_limit)
+    if not risk_ids:
+        logger_celery.info(
+            "[BindRisksToAnalyseReport] No risks found for report_id=%s, prompt_params=%s",
+            report.report_id,
+            report.prompt_params,
+        )
+        return 0
+
+    report_risks = [AnalyseReportRisk(report=report, risk_id=rid) for rid in risk_ids]
+    AnalyseReportRisk.objects.bulk_create(report_risks, ignore_conflicts=True)
+
+    report.risk_count = len(risk_ids)
+    report.save(update_fields=["risk_count"])
+
+    logger_celery.info(
+        "[BindRisksToAnalyseReport] Linked %d risks to report_id=%s",
+        len(risk_ids),
+        report.report_id,
+    )
+    return len(risk_ids)

--- a/src/backend/services/web/risk/report/renderer.py
+++ b/src/backend/services/web/risk/report/renderer.py
@@ -27,6 +27,7 @@ from blueapps.utils.logger import logger_celery
 from jinja2 import nodes
 from markupsafe import Markup
 
+from core.observability import submit_with_observation_context
 from core.render import jinja2_environment
 from services.web.risk.report.markdown import render_ai_markdown
 from services.web.risk.report.providers import Provider
@@ -323,7 +324,7 @@ def _render_template(template: str, providers: list[Provider], variables: dict[s
     with ThreadPoolExecutor(max_workers=min(max_workers, len(provider_calls))) as executor:
         # 提交所有任务，直接使用call中的provider实例
         future_to_call: dict[Future, ProviderCall] = {
-            executor.submit(_execute_provider_call, call): call for call in provider_calls
+            submit_with_observation_context(executor, _execute_provider_call, call): call for call in provider_calls
         }
 
         # 收集结果

--- a/src/backend/services/web/risk/resources/analyse_report.py
+++ b/src/backend/services/web/risk/resources/analyse_report.py
@@ -27,6 +27,7 @@ from urllib.parse import unquote, urlparse
 from blueapps.utils.request_provider import get_request_username
 from celery.result import AsyncResult
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
@@ -46,6 +47,7 @@ from services.web.risk.models import (
     AnalyseReportScenario,
     Risk,
 )
+from services.web.risk.report.analyse_report import bind_risks_to_analyse_report
 from services.web.risk.report.markdown import render_ai_markdown
 from services.web.risk.serializers import (
     DeleteAnalyseReportRequestSerializer,
@@ -61,6 +63,8 @@ from services.web.risk.serializers import (
     ListAnalyseReportScenarioResponseSerializer,
     RetrieveAnalyseReportRequestSerializer,
     RetrieveAnalyseReportResponseSerializer,
+    RetryAnalyseReportRequestSerializer,
+    RetryAnalyseReportResponseSerializer,
     TaskResultRequestSerializer,
     TaskResultResponseSerializer,
     UpdateAnalyseReportRequestSerializer,
@@ -143,17 +147,19 @@ class GenerateAnalyseReport(AnalyseReportMeta):
         generate_title = validated_request_data.get("generate_title", False)
         title = _build_analyse_report_temp_title(scenario) if generate_title else validated_request_data["title"]
         title_task_id = str(uuid.uuid4()) if generate_title else ""
-        report = AnalyseReport.objects.create(
-            title=title,
-            report_type=validated_request_data["report_type"],
-            scenario=scenario,
-            analysis_scope=validated_request_data.get("analysis_scope", ""),
-            status=AnalyseReportStatus.GENERATING,
-            title_generating=generate_title,
-            title_task_id=title_task_id,
-            prompt_params=prompt_params,
-            custom_prompt=validated_request_data.get("custom_prompt", ""),
-        )
+        with transaction.atomic():
+            report = AnalyseReport.objects.create(
+                title=title,
+                report_type=validated_request_data["report_type"],
+                scenario=scenario,
+                analysis_scope=validated_request_data.get("analysis_scope", ""),
+                status=AnalyseReportStatus.GENERATING,
+                title_generating=generate_title,
+                title_task_id=title_task_id,
+                prompt_params=prompt_params,
+                custom_prompt=validated_request_data.get("custom_prompt", ""),
+            )
+            bind_risks_to_analyse_report(report)
 
         # 4. 提交 Celery 异步任务
         try:
@@ -181,6 +187,50 @@ class GenerateAnalyseReport(AnalyseReportMeta):
             "status": "PENDING",
             "title_task_id": title_task_id,
             "title_task_status": title_task_status,
+        }
+
+
+class RetryAnalyseReport(AnalyseReportMeta):
+    """重试 AI 分析报告"""
+
+    name = gettext_lazy("重试AI分析报告")
+    RequestSerializer = RetryAnalyseReportRequestSerializer
+    ResponseSerializer = RetryAnalyseReportResponseSerializer
+
+    def perform_request(self, validated_request_data):
+        report_id = validated_request_data["report_id"]
+        report = self.get_user_report(report_id)
+
+        updated = AnalyseReport.objects.filter(
+            report_id=report.report_id,
+            status__in=[AnalyseReportStatus.SUCCESS, AnalyseReportStatus.FAILED],
+        ).update(
+            status=AnalyseReportStatus.GENERATING,
+            content="",
+            task_id="",
+            extra_info={},
+            updated_at=timezone.now(),
+        )
+        if not updated:
+            raise drf_serializers.ValidationError({"status": gettext_lazy("报告生成中，不能重复重试")})
+
+        report.refresh_from_db()
+        try:
+            task = generate_analyse_report.delay(report_id=report.report_id)
+        except Exception as exc:
+            _mark_analyse_report_submit_failed(report, exc)
+            logging.getLogger(__name__).exception(
+                "[RetryAnalyseReport] Submit task failed report_id=%s",
+                report.report_id,
+            )
+            raise
+
+        report.task_id = task.id
+        report.save(update_fields=["task_id", "updated_at"])
+        return {
+            "report_id": report.report_id,
+            "task_id": task.id,
+            "status": "PENDING",
         }
 
 

--- a/src/backend/services/web/risk/resources/analyse_report.py
+++ b/src/backend/services/web/risk/resources/analyse_report.py
@@ -278,6 +278,10 @@ class ListAnalyseReport(AnalyseReportMeta):
     RequestSerializer = ListAnalyseReportRequestSerializer
     ResponseSerializer = ListAnalyseReportResponseSerializer
     many_response_data = True
+    SEARCH_FILTERS = {
+        "title": "title__icontains",
+        "analysis_scope": "analysis_scope__icontains",
+    }
 
     def perform_request(self, validated_request_data):
         # 默认按当前用户过滤，只返回自己创建的报告
@@ -289,6 +293,11 @@ class ListAnalyseReport(AnalyseReportMeta):
             queryset = queryset.filter(
                 Q(title__icontains=keyword) | Q(analysis_scope__icontains=keyword) | Q(created_by__icontains=keyword)
             )
+
+        for request_field, lookup in self.SEARCH_FILTERS.items():
+            value = validated_request_data.get(request_field)
+            if value:
+                queryset = queryset.filter(**{lookup: value})
 
         # report_type 筛选
         report_type = validated_request_data.get("report_type")

--- a/src/backend/services/web/risk/resources/risk.py
+++ b/src/backend/services/web/risk/resources/risk.py
@@ -19,6 +19,7 @@ to the current version of the project delivered to anyone in the future.
 import abc
 import json
 import logging
+import time
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass
@@ -65,8 +66,16 @@ from apps.permission.handlers.resource_types import ResourceEnum
 from apps.sops.constants import SOPSTaskOperation, SOPSTaskStatus
 from core.exceptions import RiskStatusInvalid
 from core.models import get_request_username
+from core.observability import (
+    OBSERVATION_METRIC_STATUS_ERROR,
+    OBSERVATION_METRIC_STATUS_SUCCESS,
+    report_observation_metric,
+    set_span_attributes,
+    start_observation_span,
+)
 from core.utils.data import build_preserved_order_queryset, choices_to_dict
 from services.web.common.constants import ScopeQueryField
+from services.web.common.monitor import NL2RiskFilterFailedEvent
 from services.web.common.scope_permission import ScopeContext, ScopePermission
 from services.web.databus.constants import (
     ASSET_RISK_BKBASE_RT_ID_KEY,
@@ -1550,64 +1559,142 @@ class NL2RiskFilter(RiskMeta):
         scenes = validated_request_data.get("scenes", [])
         scope_type = validated_request_data.get(ScopeQueryField.SCOPE_TYPE)
         scope_id = validated_request_data.get(ScopeQueryField.SCOPE_ID)
-        thread_id = validated_request_data.get("thread_id") or str(uuid.uuid4())
+        input_thread_id = validated_request_data.get("thread_id")
+        thread_id = input_thread_id or str(uuid.uuid4())
         username = get_request_username()
+        metric_started_at = time.perf_counter()
 
-        request_params = {
-            "query": query,
-            "tags": tags,
-            "strategies": strategies,
-            "scenes": scenes,
-            "scope_type": scope_type,
-            "scope_id": scope_id,
-            "thread_id": thread_id,
-        }
-        user_message = build_nl2risk_user_message(
-            query=query,
-            tags=tags,
-            strategies=strategies,
-            username=username,
-            scenes=scenes,
-            scope_type=scope_type,
-            scope_id=scope_id,
-        )
-
-        try:
-            result = api.bk_plugins_ai_agent.chat_completion(
-                agent_code=AIAgentCode.RISK_SEARCH,
-                user=username,
-                input=user_message,
-                chat_history=[],
-                execute_kwargs={"stream": False, "thread_id": thread_id},
+        with start_observation_span(
+            "risk.nl2risk_filter.generate",
+            attributes={
+                "bk_audit.service": "risk",
+                "bk_audit.operation": "nl2risk_filter",
+                "bk_audit.scope.type": scope_type,
+                "bk_audit.scope.has_scope_id": bool(scope_id),
+                "bk_audit.nl2risk.tags_count": len(tags),
+                "bk_audit.nl2risk.strategies_count": len(strategies),
+                "bk_audit.nl2risk.scenes_count": len(scenes),
+                "bk_audit.nl2risk.has_thread_id": bool(input_thread_id),
+            },
+        ) as span:
+            request_params = {
+                "query": query,
+                "tags": tags,
+                "strategies": strategies,
+                "scenes": scenes,
+                "scope_type": scope_type,
+                "scope_id": scope_id,
+                "thread_id": thread_id,
+            }
+            user_message = build_nl2risk_user_message(
+                query=query,
+                tags=tags,
+                strategies=strategies,
+                username=username,
+                scenes=scenes,
+                scope_type=scope_type,
+                scope_id=scope_id,
             )
-        except Exception as e:
-            logger.exception("[NL2RiskFilter] AI platform call failed: %s", e)
+
+            try:
+                with start_observation_span(
+                    "risk.nl2risk_filter.call_ai_agent",
+                    attributes={
+                        "bk_audit.service": "risk",
+                        "bk_audit.operation": "nl2risk_filter",
+                        "bk_audit.stage": "call_ai_agent",
+                        "bk_audit.scope.type": scope_type,
+                    },
+                ):
+                    result = api.bk_plugins_ai_agent.chat_completion(
+                        agent_code=AIAgentCode.RISK_SEARCH,
+                        user=username,
+                        input=user_message,
+                        chat_history=[],
+                        execute_kwargs={"stream": False, "thread_id": thread_id},
+                    )
+            except Exception as e:
+                logger.exception("[NL2RiskFilter] AI platform call failed: %s", e)
+                NL2RiskFilterLog.save_nl2risk_filter_log(
+                    username=username,
+                    query=query,
+                    request_params=request_params,
+                    response_data={},
+                    status=NL2RiskFilterLogStatus.API_ERROR,
+                    error_message=str(e),
+                )
+                NL2RiskFilterFailedEvent(
+                    target="nl2risk_filter",
+                    context={
+                        "status": NL2RiskFilterLogStatus.API_ERROR,
+                        "scope_type": scope_type,
+                        "error_type": e.__class__.__name__,
+                    },
+                    extra={"error": str(e)},
+                ).async_report()
+                report_observation_metric(
+                    name="risk.nl2risk_filter.generate",
+                    started_at=metric_started_at,
+                    status=OBSERVATION_METRIC_STATUS_ERROR,
+                    error_type=e.__class__.__name__,
+                    dimensions={
+                        "service": "risk",
+                        "operation": "nl2risk_filter",
+                        "scope_type": scope_type,
+                        "business_status": NL2RiskFilterLogStatus.API_ERROR,
+                    },
+                )
+                raise NL2RiskFilterServiceError()
+
+            raw_text = str(result)
+            with start_observation_span(
+                "risk.nl2risk_filter.parse_result",
+                attributes={
+                    "bk_audit.service": "risk",
+                    "bk_audit.operation": "nl2risk_filter",
+                    "bk_audit.stage": "parse_result",
+                },
+            ):
+                filter_conditions, message = extract_filter_conditions_from_ai_result(result)
+            response_data = {"filter_conditions": filter_conditions, "thread_id": thread_id, "message": message}
+
+            status = NL2RiskFilterLogStatus.SUCCESS if filter_conditions else NL2RiskFilterLogStatus.PARSE_FAILED
+            metric_status = (
+                OBSERVATION_METRIC_STATUS_SUCCESS
+                if status == NL2RiskFilterLogStatus.SUCCESS
+                else OBSERVATION_METRIC_STATUS_ERROR
+            )
+            metric_error_type = "" if status == NL2RiskFilterLogStatus.SUCCESS else status
+            set_span_attributes(
+                span,
+                {
+                    "bk_audit.nl2risk.status": status,
+                    "bk_audit.nl2risk.filter_condition_count": len(filter_conditions),
+                },
+            )
             NL2RiskFilterLog.save_nl2risk_filter_log(
                 username=username,
                 query=query,
                 request_params=request_params,
-                response_data={},
-                status=NL2RiskFilterLogStatus.API_ERROR,
-                error_message=str(e),
+                response_data=response_data,
+                status=status,
+                result=raw_text,
+                message=message,
             )
-            raise NL2RiskFilterServiceError()
+            report_observation_metric(
+                name="risk.nl2risk_filter.generate",
+                started_at=metric_started_at,
+                status=metric_status,
+                error_type=metric_error_type,
+                dimensions={
+                    "service": "risk",
+                    "operation": "nl2risk_filter",
+                    "scope_type": scope_type,
+                    "business_status": status,
+                },
+            )
 
-        raw_text = str(result)
-        filter_conditions, message = extract_filter_conditions_from_ai_result(result)
-        response_data = {"filter_conditions": filter_conditions, "thread_id": thread_id, "message": message}
-
-        status = NL2RiskFilterLogStatus.SUCCESS if filter_conditions else NL2RiskFilterLogStatus.PARSE_FAILED
-        NL2RiskFilterLog.save_nl2risk_filter_log(
-            username=username,
-            query=query,
-            request_params=request_params,
-            response_data=response_data,
-            status=status,
-            result=raw_text,
-            message=message,
-        )
-
-        return response_data
+            return response_data
 
 
 class ListEventFieldsByStrategyBrief(ListEventFieldsByStrategy):

--- a/src/backend/services/web/risk/serializers.py
+++ b/src/backend/services/web/risk/serializers.py
@@ -1730,6 +1730,20 @@ class ListAnalyseReportRequestSerializer(serializers.Serializer):
         default="",
         help_text=gettext_lazy("模糊搜索报告标题、分析范围、生成人"),
     )
+    title = serializers.CharField(
+        label=gettext_lazy("报告标题"),
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text=gettext_lazy("按报告标题模糊筛选"),
+    )
+    analysis_scope = serializers.CharField(
+        label=gettext_lazy("分析范围"),
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text=gettext_lazy("按分析范围模糊筛选"),
+    )
     report_type = serializers.ChoiceField(
         label=gettext_lazy("报告类型筛选"),
         choices=AnalyseReportType.choices,

--- a/src/backend/services/web/risk/serializers.py
+++ b/src/backend/services/web/risk/serializers.py
@@ -1704,6 +1704,20 @@ class GenerateAnalyseReportResponseSerializer(serializers.Serializer):
     title_task_status = serializers.CharField(label=gettext_lazy("标题生成任务状态"), required=False, allow_blank=True)
 
 
+class RetryAnalyseReportRequestSerializer(serializers.Serializer):
+    """重试 AI 分析报告请求"""
+
+    report_id = serializers.IntegerField(label=gettext_lazy("报告ID"))
+
+
+class RetryAnalyseReportResponseSerializer(serializers.Serializer):
+    """重试 AI 分析报告响应"""
+
+    report_id = serializers.IntegerField(label=gettext_lazy("报告ID"))
+    task_id = serializers.CharField(label=gettext_lazy("异步任务ID"))
+    status = serializers.CharField(label=gettext_lazy("任务状态"))
+
+
 class ListAnalyseReportRequestSerializer(serializers.Serializer):
     """历史报告列表请求"""
 

--- a/src/backend/services/web/risk/tasks.py
+++ b/src/backend/services/web/risk/tasks.py
@@ -19,6 +19,7 @@ to the current version of the project delivered to anyone in the future.
 import datetime
 import json
 import os
+import time
 from typing import Any
 
 from bk_resource import api
@@ -45,8 +46,18 @@ from apps.meta.models import GlobalMetaConfig
 from apps.notice.handlers import ErrorMsgHandler
 from apps.sops.constants import SOPSTaskStatus
 from core.lock import lock
+from core.observability import (
+    OBSERVATION_METRIC_STATUS_ERROR,
+    OBSERVATION_METRIC_STATUS_SUCCESS,
+    report_observation_metric,
+    set_span_attributes,
+    start_observation_span,
+)
 from core.utils.data import data_chunks
-from services.web.common.monitor import RiskExportFailedEvent
+from services.web.common.monitor import (
+    AnalyseReportGenerateFailedEvent,
+    RiskExportFailedEvent,
+)
 from services.web.databus.constants import ASSET_RISK_BKBASE_RT_ID_KEY
 from services.web.risk.constants import (
     BULK_ADD_EVENT_SIZE,
@@ -220,7 +231,7 @@ def report_risk_export_failed_event(username: str, risk_count: int, error: Excep
         context={"username": username, "risk_count": str(risk_count)},
         extra={"error": str(error)},
     )
-    event.report()
+    event.async_report()
 
 
 @celery_app.task(
@@ -233,75 +244,127 @@ def export_risks_to_mail(self, username: str, risk_ids: list[str], risk_view_typ
     """异步导出风险并通过邮件附件发送给当前用户。"""
 
     total = len(risk_ids)
-    logger_celery.info(
-        "[RiskExportTask] start username=%s total=%s risk_view_type=%s requested_at=%s",
-        username,
-        total,
-        risk_view_type,
-        requested_at,
-    )
-    self.update_state(state="RUNNING", meta={"current": 0, "total": total})
-    service = RiskExportService(
-        username=username,
-        risk_ids=risk_ids,
-        risk_view_type=risk_view_type,
-    )
-    try:
-        export_file = service.build_export_file()
+    metric_started_at = time.perf_counter()
+    with start_observation_span(
+        "risk.export_risks_to_mail",
+        attributes={
+            "bk_audit.service": "risk",
+            "bk_audit.operation": "export_risks_to_mail",
+            "bk_audit.risk.count": total,
+            "bk_audit.risk.view_type": risk_view_type,
+        },
+    ) as span:
         logger_celery.info(
-            "[RiskExportTask] export file built username=%s total=%s filename=%s",
+            "[RiskExportTask] start username=%s total=%s risk_view_type=%s requested_at=%s",
             username,
-            export_file.total,
-            export_file.filename,
+            total,
+            risk_view_type,
+            requested_at,
         )
-        self.update_state(state="PROGRESS", meta={"current": total, "total": total})
-        logger_celery.info(
-            "[RiskExportTask] send mail start username=%s total=%s filename=%s",
-            username,
-            export_file.total,
-            export_file.filename,
+        self.update_state(state="RUNNING", meta={"current": 0, "total": total})
+        service = RiskExportService(
+            username=username,
+            risk_ids=risk_ids,
+            risk_view_type=risk_view_type,
         )
-        service.send_mail(export_file=export_file, requested_at=requested_at)
-        logger_celery.info(
-            "[RiskExportTask] mail sent username=%s total=%s filename=%s",
-            username,
-            export_file.total,
-            export_file.filename,
-        )
-        return {"total": export_file.total, "filename": export_file.filename}
-    except Exception as exc:
-        retries = getattr(self.request, "retries", 0)
-        max_retries = self.max_retries
         try:
-            if retries >= max_retries:
-                raise MaxRetriesExceededError()
-            logger_celery.warning(
-                "[RiskExportTaskRetrying] username=%s total=%s retries=%s max_retries=%s countdown=%s error=%s",
+            with start_observation_span(
+                "risk.export_risks_to_mail.build_file",
+                attributes={
+                    "bk_audit.service": "risk",
+                    "bk_audit.operation": "export_risks_to_mail",
+                    "bk_audit.stage": "build_file",
+                    "bk_audit.risk.count": total,
+                    "bk_audit.risk.view_type": risk_view_type,
+                },
+            ):
+                export_file = service.build_export_file()
+            set_span_attributes(span, {"bk_audit.export.total": export_file.total})
+            logger_celery.info(
+                "[RiskExportTask] export file built username=%s total=%s filename=%s",
                 username,
-                total,
-                retries,
-                max_retries,
-                settings.RISK_EXPORT_TASK_RETRY_DELAY,
-                exc,
-                exc_info=True,
+                export_file.total,
+                export_file.filename,
             )
-            # 不传 exc，确保达到最大重试次数时 Celery 抛 MaxRetriesExceededError。
-            raise self.retry(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
-        except MaxRetriesExceededError:
-            logger_celery.error(
-                "[RiskExportTaskFailed] username=%s total=%s retries=%s max_retries=%s",
+            self.update_state(state="PROGRESS", meta={"current": total, "total": total})
+            logger_celery.info(
+                "[RiskExportTask] send mail start username=%s total=%s filename=%s",
                 username,
-                total,
-                retries,
-                max_retries,
-                exc_info=(type(exc), exc, exc.__traceback__),
+                export_file.total,
+                export_file.filename,
             )
+            with start_observation_span(
+                "risk.export_risks_to_mail.send_mail",
+                attributes={
+                    "bk_audit.service": "risk",
+                    "bk_audit.operation": "export_risks_to_mail",
+                    "bk_audit.stage": "send_mail",
+                    "bk_audit.risk.count": export_file.total,
+                    "bk_audit.risk.view_type": risk_view_type,
+                },
+            ):
+                service.send_mail(export_file=export_file, requested_at=requested_at)
+            logger_celery.info(
+                "[RiskExportTask] mail sent username=%s total=%s filename=%s",
+                username,
+                export_file.total,
+                export_file.filename,
+            )
+            report_observation_metric(
+                name="risk.export_risks_to_mail",
+                started_at=metric_started_at,
+                status=OBSERVATION_METRIC_STATUS_SUCCESS,
+                dimensions={
+                    "service": "risk",
+                    "operation": "export_risks_to_mail",
+                    "risk_view_type": risk_view_type,
+                    "business_status": "success",
+                },
+            )
+            return {"total": export_file.total, "filename": export_file.filename}
+        except Exception as exc:
+            retries = getattr(self.request, "retries", 0)
+            max_retries = self.max_retries
             try:
+                if retries >= max_retries:
+                    raise MaxRetriesExceededError()
+                set_span_attributes(span, {"bk_audit.retry.current": retries, "bk_audit.retry.max": max_retries})
+                logger_celery.warning(
+                    "[RiskExportTaskRetrying] username=%s total=%s retries=%s max_retries=%s countdown=%s error=%s",
+                    username,
+                    total,
+                    retries,
+                    max_retries,
+                    settings.RISK_EXPORT_TASK_RETRY_DELAY,
+                    exc,
+                    exc_info=True,
+                )
+                # 不传 exc，确保达到最大重试次数时 Celery 抛 MaxRetriesExceededError。
+                raise self.retry(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
+            except MaxRetriesExceededError:
+                logger_celery.error(
+                    "[RiskExportTaskFailed] username=%s total=%s retries=%s max_retries=%s",
+                    username,
+                    total,
+                    retries,
+                    max_retries,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+                report_observation_metric(
+                    name="risk.export_risks_to_mail",
+                    started_at=metric_started_at,
+                    status=OBSERVATION_METRIC_STATUS_ERROR,
+                    error_type=exc.__class__.__name__,
+                    dimensions={
+                        "service": "risk",
+                        "operation": "export_risks_to_mail",
+                        "risk_view_type": risk_view_type,
+                        "business_status": "failed",
+                    },
+                )
                 report_risk_export_failed_event(username=username, risk_count=total, error=exc)
-            except Exception:  # NOCC:broad-except(监控上报失败不能遮蔽原始任务失败)
-                logger_celery.exception("[RiskExportTaskReportFailed] username=%s, total=%s", username, total)
-            # 让 Celery 最终 FAILURE 记录原始业务异常，而不是 MaxRetriesExceededError。
-            raise exc
+                # 让 Celery 最终 FAILURE 记录原始业务异常，而不是 MaxRetriesExceededError。
+                raise exc
 
 
 def _sync_manual_event_status(batch_size: int = 100, window: datetime.timedelta = datetime.timedelta(hours=1)) -> None:
@@ -722,94 +785,161 @@ def generate_analyse_report(self, report_id: int):
     from services.web.risk.models import AnalyseReport
 
     report = AnalyseReport.objects.get(report_id=report_id)
-    started_at = timezone.now()
-    agent_request = None
-    _update_analyse_report_extra_info(report, _build_analyse_report_extra_info(started_at=started_at))
+    metric_started_at = time.perf_counter()
+    with start_observation_span(
+        "risk.analyse_report.generate",
+        attributes={
+            "bk_audit.service": "risk",
+            "bk_audit.operation": "generate_analyse_report",
+            "bk_audit.report.id": report.report_id,
+            "bk_audit.report.type": report.report_type,
+            "bk_audit.report.risk_count": report.risk_count,
+            "bk_audit.report.has_scenario": bool(report.scenario_id),
+        },
+    ) as span:
+        started_at = timezone.now()
+        agent_request = None
+        _update_analyse_report_extra_info(report, _build_analyse_report_extra_info(started_at=started_at))
 
-    try:
-        # 1. 构造分析要求 prompt
-        scenario = report.scenario
-        if scenario:
-            # 内置场景：使用场景配置的 system_prompt 作为分析要求前缀
-            analysis_request = scenario.system_prompt
-        else:
-            # 自定义分析：使用用户自定义描述
-            analysis_request = report.custom_prompt or "请使用风险查询条件查询风险详细数据生成分析报告。"
+        try:
+            # 1. 构造分析要求 prompt
+            scenario = report.scenario
+            if scenario:
+                # 内置场景：使用场景配置的 system_prompt 作为分析要求前缀
+                analysis_request = scenario.system_prompt
+            else:
+                # 自定义分析：使用用户自定义描述
+                analysis_request = report.custom_prompt or "请使用风险查询条件查询风险详细数据生成分析报告。"
 
-        # prompt_params 仅用于后端筛选并绑定报告风险；Agent 只接收报告参数配置。
-        agent_input = {
-            "报告ID": report.report_id,
-            "报告标题": report.title,
-            "报告类型": report.report_type,
-            "场景标识": scenario.scenario_key if scenario else "",
-            "分析要求": analysis_request,
-            "已绑定风险数量": report.risk_count,
-        }
-        chat_user = report.created_by or "admin"
-        execute_kwargs = {"stream": True}
-        agent_request = AnalyseReportAgentRequestInfo(
-            user=chat_user,
-            input=agent_input,
-            execute_kwargs=execute_kwargs,
-        )
-        _update_analyse_report_extra_info(
-            report,
-            _build_analyse_report_extra_info(
-                started_at=started_at,
-                agent_request=agent_request,
-            ),
-        )
-
-        # 2. 调用 Analyse Agent API（sub_agent 配置在 agent 服务中已预配置）
-        result = api.bk_plugins_ai_audit_analyse.chat_completion(
-            user=chat_user,
-            input=json.dumps(agent_input, ensure_ascii=False),
-            execute_kwargs=execute_kwargs,
-        )
-        result = _validate_analyse_report_content(result, report.report_id)
-
-        # 3. 更新报告
-        report.content = result
-        report.status = AnalyseReportStatus.SUCCESS
-        report.extra_info = _build_analyse_report_extra_info(
-            started_at=started_at,
-            ended_at=timezone.now(),
-            agent_request=agent_request,
-        )
-        report.save(update_fields=["content", "status", "extra_info", "updated_at"])
-
-        return {"report_id": report.report_id}
-
-    except Exception as exc:
-        max_retries = self.max_retries
-        current_retries = getattr(self.request, "retries", 0)
-        if max_retries is not None and current_retries >= max_retries:
-            report.status = AnalyseReportStatus.FAILED
-            report.extra_info = _build_analyse_report_extra_info(
-                started_at=started_at,
-                ended_at=timezone.now(),
-                agent_request=agent_request,
-                error=_build_analyse_report_error_info(exc, current_retries, max_retries),
+            # prompt_params 仅用于后端筛选并绑定报告风险；Agent 只接收报告参数配置。
+            agent_input = {
+                "报告ID": report.report_id,
+                "报告标题": report.title,
+                "报告类型": report.report_type,
+                "场景标识": scenario.scenario_key if scenario else "",
+                "分析要求": analysis_request,
+                "已绑定风险数量": report.risk_count,
+            }
+            chat_user = report.created_by or "admin"
+            execute_kwargs = {"stream": True}
+            agent_request = AnalyseReportAgentRequestInfo(
+                user=chat_user,
+                input=agent_input,
+                execute_kwargs=execute_kwargs,
             )
-            report.save(update_fields=["status", "extra_info", "updated_at"])
-            logger_celery.error(
-                "[GenerateAnalyseReport] Max retries reached report_id=%s retries=%s max_retries=%s",
+            _update_analyse_report_extra_info(
+                report,
+                _build_analyse_report_extra_info(
+                    started_at=started_at,
+                    agent_request=agent_request,
+                ),
+            )
+
+            # 2. 调用 Analyse Agent API（sub_agent 配置在 agent 服务中已预配置）
+            with start_observation_span(
+                "risk.analyse_report.call_ai_agent",
+                attributes={
+                    "bk_audit.service": "risk",
+                    "bk_audit.operation": "generate_analyse_report",
+                    "bk_audit.stage": "call_ai_agent",
+                    "bk_audit.report.type": report.report_type,
+                    "bk_audit.report.risk_count": report.risk_count,
+                },
+            ):
+                result = api.bk_plugins_ai_audit_analyse.chat_completion(
+                    user=chat_user,
+                    input=json.dumps(agent_input, ensure_ascii=False),
+                    execute_kwargs=execute_kwargs,
+                )
+            result = _validate_analyse_report_content(result, report.report_id)
+            set_span_attributes(span, {"bk_audit.report.content_size": len(result or "")})
+
+            # 3. 更新报告
+            with start_observation_span(
+                "risk.analyse_report.save_result",
+                attributes={
+                    "bk_audit.service": "risk",
+                    "bk_audit.operation": "generate_analyse_report",
+                    "bk_audit.stage": "save_result",
+                    "bk_audit.report.type": report.report_type,
+                },
+            ):
+                report.content = result
+                report.status = AnalyseReportStatus.SUCCESS
+                report.extra_info = _build_analyse_report_extra_info(
+                    started_at=started_at,
+                    ended_at=timezone.now(),
+                    agent_request=agent_request,
+                )
+                report.save(update_fields=["content", "status", "extra_info", "updated_at"])
+
+            report_observation_metric(
+                name="risk.analyse_report.generate",
+                started_at=metric_started_at,
+                status=OBSERVATION_METRIC_STATUS_SUCCESS,
+                dimensions={
+                    "service": "risk",
+                    "operation": "generate_analyse_report",
+                    "report_type": report.report_type,
+                    "has_scenario": bool(report.scenario_id),
+                    "business_status": AnalyseReportStatus.SUCCESS,
+                },
+            )
+            return {"report_id": report.report_id}
+
+        except Exception as exc:
+            max_retries = self.max_retries
+            current_retries = getattr(self.request, "retries", 0)
+            set_span_attributes(span, {"bk_audit.retry.current": current_retries, "bk_audit.retry.max": max_retries})
+            if max_retries is not None and current_retries >= max_retries:
+                report.status = AnalyseReportStatus.FAILED
+                report.extra_info = _build_analyse_report_extra_info(
+                    started_at=started_at,
+                    ended_at=timezone.now(),
+                    agent_request=agent_request,
+                    error=_build_analyse_report_error_info(exc, current_retries, max_retries),
+                )
+                report.save(update_fields=["status", "extra_info", "updated_at"])
+                logger_celery.error(
+                    "[GenerateAnalyseReport] Max retries reached report_id=%s retries=%s max_retries=%s",
+                    report_id,
+                    current_retries,
+                    max_retries,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+                report_observation_metric(
+                    name="risk.analyse_report.generate",
+                    started_at=metric_started_at,
+                    status=OBSERVATION_METRIC_STATUS_ERROR,
+                    error_type=exc.__class__.__name__,
+                    dimensions={
+                        "service": "risk",
+                        "operation": "generate_analyse_report",
+                        "report_type": report.report_type,
+                        "has_scenario": bool(report.scenario_id),
+                        "business_status": AnalyseReportStatus.FAILED,
+                    },
+                )
+                AnalyseReportGenerateFailedEvent(
+                    target=str(report.report_id),
+                    context={
+                        "report_type": report.report_type,
+                        "has_scenario": bool(report.scenario_id),
+                        "error_type": exc.__class__.__name__,
+                    },
+                    extra={"report_id": report.report_id, "error": str(exc)},
+                ).async_report()
+                raise
+            logger_celery.warning(
+                "[GenerateAnalyseReport] Retrying report_id=%s retries=%s max_retries=%s countdown=%s error=%s",
                 report_id,
                 current_retries,
                 max_retries,
-                exc_info=(type(exc), exc, exc.__traceback__),
+                60,
+                exc,
+                exc_info=True,
             )
-            raise
-        logger_celery.warning(
-            "[GenerateAnalyseReport] Retrying report_id=%s retries=%s max_retries=%s countdown=%s error=%s",
-            report_id,
-            current_retries,
-            max_retries,
-            60,
-            exc,
-            exc_info=True,
-        )
-        raise self.retry(exc=exc, countdown=60)
+            raise self.retry(exc=exc, countdown=60)
 
 
 def _normalize_analyse_report_ai_title(raw_title: Any, max_length: int) -> str:

--- a/src/backend/services/web/risk/tasks.py
+++ b/src/backend/services/web/risk/tasks.py
@@ -80,10 +80,7 @@ from services.web.risk.models import (
 )
 from services.web.risk.report import AIProvider
 from services.web.risk.report.markdown import render_ai_markdown
-from services.web.risk.serializers import (
-    CreateEventSerializer,
-    ListRiskRequestSerializer,
-)
+from services.web.risk.serializers import CreateEventSerializer
 from services.web.strategy_v2.constants import StrategyType
 
 cache: DefaultClient = _cache
@@ -677,64 +674,6 @@ def _build_risk_query_from_prompt_params(prompt_params: dict) -> Q:
     return q
 
 
-def _load_analyse_report_risk_ids(report, risk_limit: int) -> list:
-    """复用 ListRisk 的参数校验、权限过滤和检索分支，按报告创建人加载最终风险 ID。"""
-    from services.web.risk.resources.risk import ListRisk
-
-    list_risk = ListRisk()
-    serializer = ListRiskRequestSerializer(data=report.prompt_params or {})
-    serializer.is_valid(raise_exception=True)
-    return list_risk.load_filter_risk_ids(
-        dict(serializer.validated_data), username=report.created_by, risk_limit=risk_limit
-    )
-
-
-def _link_risks_to_report(report) -> int:
-    """
-    根据报告的 prompt_params 查询关联风险，批量创建 AnalyseReportRisk 关联记录。
-
-    Returns:
-        关联的风险数量
-    """
-    from services.web.risk.models import AnalyseReportRisk
-
-    if not report.created_by:
-        logger_celery.warning("[LinkRisksToReport] Skip report without creator, report_id=%s", report.report_id)
-        return 0
-
-    risk_limit = int(getattr(settings, "ANALYSE_REPORT_RISK_LIMIT", 100))
-    if risk_limit <= 0:
-        logger_celery.info(
-            "[LinkRisksToReport] Skip because risk limit is %s, report_id=%s", risk_limit, report.report_id
-        )
-        return 0
-
-    # 查询报告创建人实际有权限且符合条件的风险 ID 列表
-    risk_ids = _load_analyse_report_risk_ids(report, risk_limit)
-    if not risk_ids:
-        logger_celery.info(
-            "[LinkRisksToReport] No risks found for report_id=%s, prompt_params=%s",
-            report.report_id,
-            report.prompt_params,
-        )
-        return 0
-
-    # 批量创建关联记录（忽略已存在的重复记录）
-    report_risks = [AnalyseReportRisk(report=report, risk_id=rid) for rid in risk_ids]
-    AnalyseReportRisk.objects.bulk_create(report_risks, ignore_conflicts=True)
-
-    # 更新报告的 risk_count
-    report.risk_count = len(risk_ids)
-    report.save(update_fields=["risk_count"])
-
-    logger_celery.info(
-        "[LinkRisksToReport] Linked %d risks to report_id=%s",
-        len(risk_ids),
-        report.report_id,
-    )
-    return len(risk_ids)
-
-
 def _build_analyse_report_error_info(
     exc: Exception, current_retries: int, max_retries: int | None
 ) -> AnalyseReportErrorInfo:
@@ -788,9 +727,6 @@ def generate_analyse_report(self, report_id: int):
     _update_analyse_report_extra_info(report, _build_analyse_report_extra_info(started_at=started_at))
 
     try:
-        # 先根据 prompt_params 关联风险记录并填充 risk_count，失败报告也保留本次分析范围的风险数量
-        _link_risks_to_report(report)
-
         # 1. 构造分析要求 prompt
         scenario = report.scenario
         if scenario:

--- a/src/backend/services/web/risk/views.py
+++ b/src/backend/services/web/risk/views.py
@@ -438,6 +438,8 @@ class AnalyseReportViewSet(ResourceViewSet):
         ResourceRoute("GET", resource.risk.list_analyse_report_scenario, endpoint="scenarios"),
         # 生成报告（异步）
         ResourceRoute("POST", resource.risk.generate_analyse_report, endpoint="generate"),
+        # 重试报告（异步）
+        ResourceRoute("POST", resource.risk.retry_analyse_report, pk_field="report_id", endpoint="retry"),
         # 查询任务状态
         ResourceRoute("GET", resource.risk.get_analyse_report_task_result, endpoint="task"),
         # 历史报告列表（POST支持复杂搜索）

--- a/src/backend/services/web/strategy_v2/resources.py
+++ b/src/backend/services/web/strategy_v2/resources.py
@@ -65,6 +65,7 @@ from apps.permission.handlers.drf import ActionPermission
 from apps.permission.handlers.permission import Permission
 from apps.permission.handlers.resource_types import ResourceEnum
 from core.exceptions import PermissionException
+from core.observability import submit_with_observation_context
 from core.utils.data import choices_to_dict, compare_dict_specific_keys
 from core.utils.page import paginate_queryset
 from services.web.analyze.constants import (
@@ -1270,9 +1271,13 @@ class GetRTMeta(StrategyV2Base, CacheResource):
 
         # 创建一个线程池来并发执行任务
         with ThreadPoolExecutor(max_workers=3) as executor:
-            futures.append(executor.submit(self.get_meta, result_table_id))
-            futures.append(executor.submit(self.get_data_manager, result_table_id))
-            futures.append(executor.submit(self.get_sensitivity_info, result_table_id))
+
+            def submit(callback):
+                return submit_with_observation_context(executor, callback, result_table_id)
+
+            futures.append(submit(self.get_meta))
+            futures.append(submit(self.get_data_manager))
+            futures.append(submit(self.get_sensitivity_info))
 
             # 获取并合并结果
             result = {}

--- a/src/backend/tests/test_core/test_observability.py
+++ b/src/backend/tests/test_core/test_observability.py
@@ -1,0 +1,312 @@
+from unittest import mock
+
+from bk_resource import APIResource
+from django.test import SimpleTestCase, override_settings
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+
+from core.monitor import Event, Metric
+from core.observability import (
+    OBSERVATION_METRIC_STATUS_SUCCESS,
+    BKResourceAPIInstrumentor,
+    report_observation_metric,
+    start_observation_span,
+)
+
+
+class DummyAPIResource(APIResource):
+    module_name = "bk_dummy"
+    method = "POST"
+    base_url = "https://example.com/api"
+    action = "/v1/do_something/"
+
+
+class DummyEvent(Event):
+    name = "dummy_event"
+    documentation = "dummy event"
+    labelnames = ["status", "error_type"]
+    data_id = 321
+    access_token = "event-token"
+
+
+class TestMonitorPayloads(SimpleTestCase):
+    def test_event_builds_single_record_payload(self):
+        event = DummyEvent(
+            target="nl2risk_filter",
+            context={"status": "error", "error_type": "ValueError"},
+            extra={"error": "failed"},
+        )
+
+        with mock.patch("core.monitor.report_event_to_bk_monitor.delay") as mock_delay:
+            event.async_report()
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        self.assertEqual(payload["data_id"], 321)
+        self.assertEqual(payload["access_token"], "event-token")
+        self.assertEqual(len(payload["data"]), 1)
+        self.assertEqual(payload["data"][0]["event_name"], "dummy_event")
+        self.assertEqual(payload["data"][0]["target"], "nl2risk_filter")
+        self.assertEqual(payload["data"][0]["dimension"]["status"], "error")
+        self.assertIn("error=failed", payload["data"][0]["event"]["content"])
+
+    def test_event_builds_multi_record_payload(self):
+        event = DummyEvent(
+            records=[
+                {
+                    "target": "nl2risk_filter",
+                    "context": {"status": "api_error", "error_type": "ValueError"},
+                    "extra": {"error": "api failed"},
+                },
+                {
+                    "target": "analyse_report",
+                    "context": {"status": "failed", "error_type": "RuntimeError"},
+                    "extra": {"error": "generate failed"},
+                },
+            ]
+        )
+
+        payload = event.to_json()
+
+        self.assertEqual(len(payload["data"]), 2)
+        self.assertEqual(payload["data"][0]["target"], "nl2risk_filter")
+        self.assertEqual(payload["data"][0]["dimension"]["status"], "api_error")
+        self.assertIn("error=api failed", payload["data"][0]["event"]["content"])
+        self.assertEqual(payload["data"][1]["target"], "analyse_report")
+        self.assertEqual(payload["data"][1]["dimension"]["status"], "failed")
+        self.assertIn("error=generate failed", payload["data"][1]["event"]["content"])
+
+    @mock.patch("core.monitor.api.bk_monitor.report_event", side_effect=RuntimeError("bkm failed"))
+    def test_event_report_swallows_monitor_error(self, mock_report_event):
+        event = DummyEvent(target="nl2risk_filter", context={"status": "error"})
+
+        self.assertIsNone(event.report())
+        mock_report_event.assert_called_once()
+
+    @mock.patch("core.monitor.report_event_to_bk_monitor.delay", side_effect=RuntimeError("celery failed"))
+    def test_event_async_report_swallows_enqueue_error(self, mock_delay):
+        event = DummyEvent(target="nl2risk_filter", context={"status": "error"})
+
+        self.assertIsNone(event.async_report())
+        mock_delay.assert_called_once()
+
+
+class TestObservationMetric(SimpleTestCase):
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=456, LOG_EXPORT_STATUS_ACCESS_TOKEN="log-token")
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay")
+    def test_metric_builds_single_record_payload(self, mock_delay):
+        metric = Metric(
+            metrics={"call_count": 1, "duration_ms": 100},
+            dimension={
+                "span_name": "risk.nl2risk_filter.generate",
+                "status": "success",
+                "operation": "nl2risk_filter",
+            },
+        )
+
+        metric.async_report()
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        self.assertEqual(payload["data_id"], 456)
+        self.assertEqual(payload["access_token"], "log-token")
+        data = payload["data"][0]
+        self.assertEqual(data["target"], "bk_audit")
+        self.assertEqual(data["metrics"], {"call_count": 1, "duration_ms": 100})
+        self.assertEqual(data["dimension"]["operation"], "nl2risk_filter")
+        self.assertEqual(data["dimension"]["status"], "success")
+        self.assertIn("job", data["dimension"])
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=456, LOG_EXPORT_STATUS_ACCESS_TOKEN="log-token")
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay")
+    def test_metric_builds_multi_record_payload(self, mock_delay):
+        metric = Metric(
+            records=[
+                {
+                    "metrics": {"call_count": 1, "duration_ms": 100},
+                    "dimension": {"operation": "nl2risk_filter", "status": "success"},
+                },
+                {
+                    "metrics": {"call_count": 1, "duration_ms": 200},
+                    "dimension": {"operation": "generate_analyse_report", "status": "error"},
+                    "target": "bk_audit_worker",
+                },
+            ]
+        )
+
+        metric.async_report()
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        self.assertEqual(len(payload["data"]), 2)
+        self.assertEqual(payload["data"][0]["target"], "bk_audit")
+        self.assertEqual(payload["data"][0]["dimension"]["operation"], "nl2risk_filter")
+        self.assertEqual(payload["data"][1]["target"], "bk_audit_worker")
+        self.assertEqual(payload["data"][1]["dimension"]["operation"], "generate_analyse_report")
+        self.assertIn("job", payload["data"][0]["dimension"])
+        self.assertIn("job", payload["data"][1]["dimension"])
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=456, LOG_EXPORT_STATUS_ACCESS_TOKEN="log-token")
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay", side_effect=RuntimeError("celery failed"))
+    def test_metric_async_report_swallows_enqueue_error(self, mock_delay):
+        metric = Metric(metrics={"call_count": 1}, dimension={"operation": "nl2risk_filter"})
+
+        self.assertIsNone(metric.async_report())
+        mock_delay.assert_called_once()
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=456, LOG_EXPORT_STATUS_ACCESS_TOKEN="log-token")
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay")
+    def test_report_observation_metric_reuses_log_export_status_config(self, mock_delay):
+        report_observation_metric(
+            name="risk.nl2risk_filter.generate",
+            started_at=0,
+            status=OBSERVATION_METRIC_STATUS_SUCCESS,
+            dimensions={
+                "service": "risk",
+                "operation": "nl2risk_filter",
+                "status": "caller_status",
+            },
+        )
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        self.assertEqual(payload["data_id"], 456)
+        self.assertEqual(payload["access_token"], "log-token")
+        self.assertEqual(len(payload["data"]), 1)
+        data = payload["data"][0]
+        self.assertEqual(data["target"], "bk_audit")
+        self.assertEqual(data["metrics"]["call_count"], 1)
+        self.assertGreaterEqual(data["metrics"]["duration_ms"], 0)
+        self.assertEqual(data["dimension"]["span_name"], "risk.nl2risk_filter.generate")
+        self.assertEqual(data["dimension"]["service"], "risk")
+        self.assertEqual(data["dimension"]["operation"], "nl2risk_filter")
+        self.assertEqual(data["dimension"]["status"], "success")
+        self.assertEqual(data["dimension"]["error_type"], "")
+        self.assertIn("job", data["dimension"])
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=0, LOG_EXPORT_STATUS_ACCESS_TOKEN="")
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay")
+    def test_report_observation_metric_skips_without_config(self, mock_delay):
+        report_observation_metric(
+            name="risk.nl2risk_filter.generate",
+            started_at=0,
+            status=OBSERVATION_METRIC_STATUS_SUCCESS,
+            dimensions={"service": "risk"},
+        )
+
+        mock_delay.assert_not_called()
+
+
+class TestBKResourceAPIInstrumentor(SimpleTestCase):
+    def setUp(self):
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        self.provider.add_span_processor(SimpleSpanProcessor(self.exporter))
+        self.provider_patch = mock.patch("core.observability.trace.get_tracer_provider", return_value=self.provider)
+        self.provider_patch.start()
+        self.instrumentor = BKResourceAPIInstrumentor()
+        self.instrumentor.instrument()
+
+    def tearDown(self):
+        self.instrumentor.uninstrument()
+        self.provider_patch.stop()
+        self.exporter.clear()
+
+    def test_api_resource_perform_request_creates_client_span(self):
+        response = mock.Mock()
+        response.json.return_value = {"result": True, "code": 0, "data": {"ok": True}}
+        response.raise_for_status.return_value = None
+        response.headers = {}
+        response.request.url = "https://example.com/api/v1/do_something/"
+        resource = DummyAPIResource()
+        resource.session = mock.Mock()
+        resource.session.request.return_value = response
+
+        result = resource.perform_request({"foo": "bar"})
+
+        self.assertEqual(result, {"ok": True})
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "api.bk_dummy.DummyAPIResource")
+        self.assertEqual(span.kind, SpanKind.CLIENT)
+        self.assertEqual(span.status.status_code, StatusCode.OK)
+        self.assertEqual(span.attributes["bk_audit.api.module"], "bk_dummy")
+        self.assertEqual(span.attributes["bk_audit.api.resource"], "DummyAPIResource")
+        self.assertEqual(span.attributes["bk_audit.api.method"], "POST")
+        self.assertEqual(span.attributes["bk_audit.api.action"], "/v1/do_something/")
+        self.assertEqual(span.attributes["bk_audit.api.status"], "success")
+
+    def test_api_resource_perform_request_marks_error_span(self):
+        class FailedAPIResource(DummyAPIResource):
+            def build_url(self, validated_request_data):
+                raise ValueError("failed")
+
+        with self.assertRaises(ValueError):
+            FailedAPIResource().perform_request({})
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "api.bk_dummy.FailedAPIResource")
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        self.assertEqual(span.attributes["bk_audit.api.status"], "error")
+        self.assertEqual(span.attributes["bk_audit.api.error_type"], "ValueError")
+
+
+class TestStartObservationSpan(SimpleTestCase):
+    def setUp(self):
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        self.provider.add_span_processor(SimpleSpanProcessor(self.exporter))
+        self.provider_patch = mock.patch("core.observability.trace.get_tracer_provider", return_value=self.provider)
+        self.provider_patch.start()
+
+    def tearDown(self):
+        self.provider_patch.stop()
+        self.exporter.clear()
+
+    def test_start_observation_span_records_attributes(self):
+        with start_observation_span(
+            "risk.nl2risk_filter.generate",
+            attributes={
+                "bk_audit.service": "risk",
+                "bk_audit.operation": "nl2risk_filter",
+            },
+        ):
+            pass
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.name, "risk.nl2risk_filter.generate")
+        self.assertEqual(span.kind, SpanKind.INTERNAL)
+        self.assertEqual(span.status.status_code, StatusCode.OK)
+        self.assertEqual(span.attributes["bk_audit.service"], "risk")
+        self.assertEqual(span.attributes["bk_audit.operation"], "nl2risk_filter")
+
+    def test_start_observation_span_marks_error(self):
+        with self.assertRaises(ValueError):
+            with start_observation_span("risk.nl2risk_filter.generate"):
+                raise ValueError("failed")
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        self.assertEqual(span.attributes["bk_audit.error_type"], "ValueError")
+
+    @mock.patch("core.monitor.report_metric_to_bk_monitor.delay")
+    def test_start_observation_span_does_not_report_metric(self, mock_delay):
+        with start_observation_span(
+            "risk.nl2risk_filter.generate",
+            attributes={
+                "bk_audit.service": "risk",
+                "bk_audit.operation": "nl2risk_filter",
+            },
+        ):
+            pass
+
+        mock_delay.assert_not_called()

--- a/src/backend/tests/test_core/test_observability.py
+++ b/src/backend/tests/test_core/test_observability.py
@@ -1,7 +1,8 @@
 from unittest import mock
 
-from bk_resource import APIResource
+from bk_resource import APIResource, Resource
 from django.test import SimpleTestCase, override_settings
+from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -21,6 +22,16 @@ class DummyAPIResource(APIResource):
     method = "POST"
     base_url = "https://example.com/api"
     action = "/v1/do_something/"
+
+
+class LocalDummyAPIResource(DummyAPIResource):
+    def perform_request(self, validated_request_data):
+        return {"value": validated_request_data.get("foo", "")}
+
+
+class LocalOuterBulkResource(Resource):
+    def perform_request(self, validated_request_data):
+        return LocalDummyAPIResource().request({"foo": validated_request_data.get("foo", "")})
 
 
 class DummyEvent(Event):
@@ -214,7 +225,7 @@ class TestBKResourceAPIInstrumentor(SimpleTestCase):
         self.provider_patch.stop()
         self.exporter.clear()
 
-    def test_api_resource_perform_request_creates_client_span(self):
+    def test_api_resource_request_creates_client_span(self):
         response = mock.Mock()
         response.json.return_value = {"result": True, "code": 0, "data": {"ok": True}}
         response.raise_for_status.return_value = None
@@ -224,7 +235,7 @@ class TestBKResourceAPIInstrumentor(SimpleTestCase):
         resource.session = mock.Mock()
         resource.session.request.return_value = response
 
-        result = resource.perform_request({"foo": "bar"})
+        result = resource.request({"foo": "bar"})
 
         self.assertEqual(result, {"ok": True})
         spans = self.exporter.get_finished_spans()
@@ -239,13 +250,13 @@ class TestBKResourceAPIInstrumentor(SimpleTestCase):
         self.assertEqual(span.attributes["bk_audit.api.action"], "/v1/do_something/")
         self.assertEqual(span.attributes["bk_audit.api.status"], "success")
 
-    def test_api_resource_perform_request_marks_error_span(self):
+    def test_api_resource_request_marks_error_span(self):
         class FailedAPIResource(DummyAPIResource):
             def build_url(self, validated_request_data):
                 raise ValueError("failed")
 
         with self.assertRaises(ValueError):
-            FailedAPIResource().perform_request({})
+            FailedAPIResource().request({})
 
         spans = self.exporter.get_finished_spans()
         self.assertEqual(len(spans), 1)
@@ -254,6 +265,54 @@ class TestBKResourceAPIInstrumentor(SimpleTestCase):
         self.assertEqual(span.status.status_code, StatusCode.ERROR)
         self.assertEqual(span.attributes["bk_audit.api.status"], "error")
         self.assertEqual(span.attributes["bk_audit.api.error_type"], "ValueError")
+
+    def test_api_resource_call_keeps_request_log_inside_client_span(self):
+        class TraceCapturingLogHandler:
+            trace_id = 0
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def record(self):
+                self.__class__.trace_id = trace.get_current_span().get_span_context().trace_id
+
+        with mock.patch("bk_resource.base.bk_resource_settings.REQUEST_LOG_HANDLER", TraceCapturingLogHandler):
+            result = LocalDummyAPIResource()({"foo": "bar"})
+
+        self.assertEqual(result, {"value": "bar"})
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].name, "api.bk_dummy.LocalDummyAPIResource")
+        self.assertEqual(TraceCapturingLogHandler.trace_id, spans[0].context.trace_id)
+
+    def test_api_resource_call_does_not_create_duplicate_request_span(self):
+        result = LocalDummyAPIResource()({"foo": "bar"})
+
+        self.assertEqual(result, {"value": "bar"})
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual([span.name for span in spans], ["api.bk_dummy.LocalDummyAPIResource"])
+
+    def test_api_resource_bulk_request_propagates_parent_context_to_child_threads(self):
+        with start_observation_span("risk.bulk.parent"):
+            result = LocalDummyAPIResource().bulk_request([{"foo": "one"}, {"foo": "two"}])
+
+        self.assertEqual(result, [{"value": "one"}, {"value": "two"}])
+        spans = self.exporter.get_finished_spans()
+        parent_span = next(span for span in spans if span.name == "risk.bulk.parent")
+        api_spans = [span for span in spans if span.name == "api.bk_dummy.LocalDummyAPIResource"]
+        self.assertEqual(len(api_spans), 2)
+        self.assertTrue(all(span.parent.span_id == parent_span.context.span_id for span in api_spans))
+
+    def test_local_resource_bulk_request_propagates_parent_context_to_inner_api(self):
+        with start_observation_span("risk.local_bulk.parent"):
+            result = LocalOuterBulkResource().bulk_request([{"foo": "one"}, {"foo": "two"}])
+
+        self.assertEqual(result, [{"value": "one"}, {"value": "two"}])
+        spans = self.exporter.get_finished_spans()
+        parent_span = next(span for span in spans if span.name == "risk.local_bulk.parent")
+        api_spans = [span for span in spans if span.name == "api.bk_dummy.LocalDummyAPIResource"]
+        self.assertEqual(len(api_spans), 2)
+        self.assertTrue(all(span.parent.span_id == parent_span.context.span_id for span in api_spans))
 
 
 class TestStartObservationSpan(SimpleTestCase):

--- a/src/backend/tests/test_databus/collector/test_etl_storage.py
+++ b/src/backend/tests/test_databus/collector/test_etl_storage.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace as _SN
 from typing import List
 from unittest import mock as _mock
 
+from django.core.management.base import CommandError
+
 from services.web.databus.collector.snapshot.join.base import AssetHandler
 from services.web.databus.collector.snapshot.join.etl_storage import (
     AssetEtlStorageHandler,
@@ -11,7 +13,11 @@ from services.web.databus.collector.snapshot.join.etl_storage import (
 from services.web.databus.constants import (
     CLEAN_CONFIG_JSON_CONF_KEY,
     JsonSchemaFieldType,
+    SnapshotRunningStatus,
     SnapShotStorageChoices,
+)
+from services.web.databus.management.commands.update_asset_etl import (
+    Command as UpdateAssetEtlCommand,
 )
 
 
@@ -175,12 +181,11 @@ def test_create_data_etl_calls_create_clean_when_no_table_id():
     assert handler.snapshot.bkbase_table_id == "table_new"
 
 
-def test_create_data_etl_calls_create_clean_with_update_when_table_id_exists():
-    """已有清洗链路时，调用 create_clean(update=True)"""
+def test_create_data_etl_skips_create_clean_when_table_id_exists():
+    """已有清洗链路时，不更新远端清洗配置"""
     handler = _make_asset_handler_instance(bkbase_table_id="existing_table")
 
     mock_etl_handler = _mock.MagicMock()
-    mock_etl_handler.create_clean.return_value = ("proc_old", "existing_table")
 
     with _mock.patch.object(
         AssetHandler,
@@ -189,8 +194,28 @@ def test_create_data_etl_calls_create_clean_with_update_when_table_id_exists():
     ):
         handler.create_data_etl()
 
-    mock_etl_handler.create_clean.assert_called_once_with(update=True)
+    mock_etl_handler.create_clean.assert_not_called()
     assert handler.snapshot.bkbase_table_id == "existing_table"
+
+
+def test_create_data_storage_skips_update_when_storage_running():
+    """已有运行中入库时，不更新远端入库配置"""
+    handler = _make_asset_handler_instance(bkbase_table_id="existing_table")
+    storage = _SN(status=SnapshotRunningStatus.RUNNING, save=_mock.MagicMock())
+    handler.snapshot.storages = _SN(
+        filter=_mock.MagicMock(return_value=_SN(first=_mock.MagicMock(return_value=storage)))
+    )
+    mock_etl_handler = _mock.MagicMock()
+
+    with _mock.patch.object(
+        AssetHandler,
+        "etl_storage_handler_cls",
+        new_callable=lambda: property(lambda self: _mock.MagicMock(return_value=mock_etl_handler)),
+    ):
+        handler.create_data_storage()
+
+    mock_etl_handler.create_storage.assert_not_called()
+    storage.save.assert_not_called()
 
 
 def test_create_clean_update_calls_put_and_restart():
@@ -251,3 +276,72 @@ def test_create_clean_create_calls_post_and_start():
     mock_start.assert_called_once_with("table_new", "proc_new")
     assert processing_id == "proc_new"
     assert table_id == "table_new"
+
+
+def test_update_asset_etl_command_updates_snapshot_custom_config():
+    """update_asset_etl 支持写入自定义配置后手动刷新清洗和入库"""
+    storage = _SN(storage_type=SnapShotStorageChoices.HDFS.value)
+    snapshot = _SN(
+        id=1,
+        bkbase_data_id=100,
+        bkbase_processing_id="proc_123",
+        custom_config={},
+        save=_mock.MagicMock(),
+        storages=_SN(all=_mock.MagicMock(return_value=[storage])),
+    )
+    mock_handler = _mock.MagicMock()
+    custom_config = {CLEAN_CONFIG_JSON_CONF_KEY: {"timestamp_len": 13}}
+
+    with (
+        _mock.patch(
+            "services.web.databus.management.commands.update_asset_etl.Snapshot.objects.get",
+            return_value=snapshot,
+        ),
+        _mock.patch(
+            "services.web.databus.management.commands.update_asset_etl.System.objects.get",
+            return_value=_SN(system_id="bk_system"),
+        ),
+        _mock.patch(
+            "services.web.databus.management.commands.update_asset_etl.ResourceType.objects.get",
+            return_value=_SN(resource_type_id="bk_resource_type"),
+        ),
+        _mock.patch(
+            "services.web.databus.management.commands.update_asset_etl.AssetEtlStorageHandler",
+            return_value=mock_handler,
+        ) as mock_handler_cls,
+    ):
+        UpdateAssetEtlCommand().handle(
+            system_id="bk_system",
+            resource_type_id="bk_resource_type",
+            custom_config=json.dumps(custom_config),
+        )
+
+    assert snapshot.custom_config == custom_config
+    snapshot.save.assert_called_once_with(update_fields=["custom_config"])
+    mock_handler_cls.assert_called_once_with(
+        data_id=100,
+        system=_mock.ANY,
+        resource_type=_mock.ANY,
+        storage_type=SnapShotStorageChoices.HDFS.value,
+        snapshot=snapshot,
+    )
+    mock_handler.create_clean.assert_called_once_with(update=True)
+    mock_handler.create_storage.assert_called_once_with(update=True)
+
+
+def test_update_asset_etl_command_rejects_invalid_custom_config():
+    """custom_config 必须是 JSON 对象"""
+    with _mock.patch(
+        "services.web.databus.management.commands.update_asset_etl.Snapshot.objects.get",
+        return_value=_SN(),
+    ):
+        try:
+            UpdateAssetEtlCommand().handle(
+                system_id="bk_system",
+                resource_type_id="bk_resource_type",
+                custom_config="[1, 2, 3]",
+            )
+        except CommandError as err:
+            assert "custom-config" in str(err)
+        else:
+            raise AssertionError("CommandError not raised")

--- a/src/backend/tests/test_report/test_renderer.py
+++ b/src/backend/tests/test_report/test_renderer.py
@@ -19,8 +19,18 @@ to the current version of the project delivered to anyone in the future.
 from unittest import mock
 
 from jinja2 import nodes
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from services.web.risk.report.providers import EventProvider
+from core.observability import start_observation_span
+from services.web.risk.report.providers import (
+    EventProvider,
+    Provider,
+    ProviderMatchResult,
+)
+from services.web.risk.report.renderer import _render_template
 from tests.base import TestCase
 
 from .constants import (
@@ -487,6 +497,42 @@ class TestRenderTemplate(TestCase):
 
         # 验证AI变量渲染
         self.assertIn("2025年12月17日", result)
+
+    def test_render_provider_thread_pool_preserves_otel_context(self):
+        """Provider 在线程池执行时应继承提交任务时的 OTel context。"""
+
+        captured_span_ids = []
+
+        class ContextProvider(Provider):
+            key = "ctx"
+
+            def match(self, node: nodes.Node, **kwargs) -> ProviderMatchResult:
+                if not isinstance(node, nodes.Getattr) or not isinstance(node.node, nodes.Name):
+                    return ProviderMatchResult(matched=False)
+                if node.node.name != self.key:
+                    return ProviderMatchResult(matched=False)
+                return ProviderMatchResult(
+                    matched=True,
+                    original_expr="ctx.value",
+                    provider=self,
+                    node_type=nodes.Getattr,
+                    call_args={"name": "ctx.value"},
+                )
+
+            def get(self, **kwargs):
+                captured_span_ids.append(trace.get_current_span().get_span_context().span_id)
+                return "context-ok"
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        with mock.patch("core.observability.trace.get_tracer_provider", return_value=provider):
+            with start_observation_span("risk.render.parent") as span:
+                parent_span_id = span.get_span_context().span_id
+                result = _render_template(template="{{ ctx.value }}", providers=[ContextProvider()], variables={})
+
+        self.assertIn("context-ok", result)
+        self.assertEqual(captured_span_ids, [parent_span_id])
 
     @mock.patch("services.web.risk.report.providers.api.bk_base.query_sync")
     def test_render_missing_provider(self, mock_query):

--- a/src/backend/tests/test_risk/test_analyse_report.py
+++ b/src/backend/tests/test_risk/test_analyse_report.py
@@ -2044,14 +2044,17 @@ class TestGenerateAnalyseReportTask(AnalyseReportTestBase):
 
         generate_analyse_report(report_id=self.report.report_id)
 
+    @mock.patch("services.web.risk.tasks.report_observation_metric")
+    @mock.patch("services.web.risk.tasks.AnalyseReportGenerateFailedEvent")
     @mock.patch("services.web.risk.tasks.timezone.now")
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_failure(self, mock_chat, mock_now):
+    def test_task_failure(self, mock_chat, mock_now, mock_event_cls, mock_report_metric):
         """测试达到最大重试次数后标记为失败"""
         start_time = datetime.datetime(2026, 6, 5, 11, 0, 0, tzinfo=datetime.timezone.utc)
         end_time = datetime.datetime(2026, 6, 5, 11, 0, 1, 500000, tzinfo=datetime.timezone.utc)
         mock_now.side_effect = [start_time, start_time, end_time, end_time, end_time]
         mock_chat.side_effect = Exception("API调用失败")
+        mock_event = mock_event_cls.return_value
 
         from services.web.risk.tasks import generate_analyse_report
 
@@ -2075,9 +2078,23 @@ class TestGenerateAnalyseReportTask(AnalyseReportTestBase):
         extra_info = AnalyseReportExtraInfo.model_validate(self.report.extra_info)
         self.assertEqual(extra_info.error.error_message, "API调用失败")
         self.assertEqual(AnalyseReportExtraInfo.model_fields["error"].description, "报告最终失败时的错误信息")
+        mock_event_cls.assert_called_once()
+        event_kwargs = mock_event_cls.call_args.kwargs
+        self.assertEqual(event_kwargs["target"], str(self.report.report_id))
+        self.assertEqual(event_kwargs["context"]["report_type"], self.report.report_type)
+        self.assertEqual(event_kwargs["context"]["error_type"], "Exception")
+        mock_event.async_report.assert_called_once()
+        mock_report_metric.assert_called_once()
+        metric_kwargs = mock_report_metric.call_args.kwargs
+        self.assertEqual(metric_kwargs["name"], "risk.analyse_report.generate")
+        self.assertEqual(metric_kwargs["status"], "error")
+        self.assertEqual(metric_kwargs["error_type"], "Exception")
+        self.assertEqual(metric_kwargs["dimensions"]["operation"], "generate_analyse_report")
+        self.assertEqual(metric_kwargs["dimensions"]["business_status"], AnalyseReportStatus.FAILED)
 
+    @mock.patch("services.web.risk.tasks.report_observation_metric")
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_keeps_generating_status_before_max_retries(self, mock_chat):
+    def test_task_keeps_generating_status_before_max_retries(self, mock_chat, mock_report_metric):
         """未达到最大重试次数前，报告状态保持生成中"""
         mock_chat.side_effect = Exception("API调用失败")
 
@@ -2090,6 +2107,7 @@ class TestGenerateAnalyseReportTask(AnalyseReportTestBase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, AnalyseReportStatus.GENERATING)
+        mock_report_metric.assert_not_called()
 
 
 class TestAnalyseReportModel(AnalyseReportTestBase):

--- a/src/backend/tests/test_risk/test_analyse_report.py
+++ b/src/backend/tests/test_risk/test_analyse_report.py
@@ -722,6 +722,18 @@ class TestListAnalyseReport(AnalyseReportTestBase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["title"], "风险综合分析报告")
 
+    def test_list_reports_filter_by_title(self):
+        """支持按报告标题单独筛选"""
+        result = self.resource.risk.list_analyse_report.request({"title": "风险综合"})
+
+        self.assertEqual([item["report_id"] for item in result], [self.report2.report_id])
+
+    def test_list_reports_filter_by_analysis_scope(self):
+        """支持按分析范围单独筛选"""
+        result = self.resource.risk.list_analyse_report.request({"analysis_scope": "近30天"})
+
+        self.assertEqual([item["report_id"] for item in result], [self.report1.report_id])
+
     def test_list_reports_only_current_user(self):
         """测试列表只返回当前用户的报告，不包含其他用户的报告"""
         result = self.resource.risk.list_analyse_report({})

--- a/src/backend/tests/test_risk/test_analyse_report.py
+++ b/src/backend/tests/test_risk/test_analyse_report.py
@@ -58,6 +58,7 @@ from services.web.risk.serializers import (
     ListAnalyseReportRiskResponseSerializer,
     ListAnalyseReportScenarioResponseSerializer,
     RetrieveAnalyseReportResponseSerializer,
+    RetryAnalyseReportResponseSerializer,
     UpdateAnalyseReportRequestSerializer,
 )
 from services.web.risk.views import AnalyseReportAPIGWViewSet
@@ -180,6 +181,15 @@ class TestListAnalyseReportScenario(AnalyseReportTestBase):
 class TestGenerateAnalyseReport(AnalyseReportTestBase):
     """测试生成AI分析报告"""
 
+    def setUp(self):
+        super().setUp()
+        self.bind_risks_patcher = mock.patch(
+            "services.web.risk.resources.analyse_report.bind_risks_to_analyse_report",
+            return_value=0,
+        )
+        self.bind_risks_patcher.start()
+        self.addCleanup(self.bind_risks_patcher.stop)
+
     @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
     def test_generate_report_with_scenario(self, mock_task):
         """测试使用内置场景生成报告"""
@@ -273,6 +283,66 @@ class TestGenerateAnalyseReport(AnalyseReportTestBase):
         self.assertEqual(report.extra_info["error"]["retry_count"], 0)
         self.assertEqual(report.extra_info["error"]["max_retries"], 0)
         AnalyseReportExtraInfo.model_validate(report.extra_info)
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    @mock.patch("services.web.risk.resources.analyse_report.bind_risks_to_analyse_report", return_value=2)
+    def test_generate_report_binds_risks_before_submit_task(self, mock_bind, mock_task):
+        """创建报告时先绑定风险快照，再投递生成任务"""
+        mock_task.delay.return_value.id = "celery-task-id-bind"
+
+        result = self.resource.risk.generate_analyse_report(
+            {
+                "scenario_key": "person_investigation",
+                "report_type": AnalyseReportType.SYSTEM,
+                "title": "创建即绑定风险",
+                "target_risks_filter": {"operator": "zhangsan"},
+            }
+        )
+
+        report = AnalyseReport.objects.get(report_id=result["report_id"])
+        mock_bind.assert_called_once_with(report)
+        mock_task.delay.assert_called_once_with(report_id=report.report_id)
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    @mock.patch("services.web.risk.resources.analyse_report.bind_risks_to_analyse_report")
+    def test_generate_report_rolls_back_when_bind_risks_failed(self, mock_bind, mock_task):
+        """绑定风险失败时不残留半创建报告"""
+        mock_bind.side_effect = RuntimeError("绑定失败")
+
+        with self.assertRaisesRegex(RuntimeError, "绑定失败"):
+            self.resource.risk.generate_analyse_report(
+                {
+                    "scenario_key": "",
+                    "report_type": AnalyseReportType.CUSTOM,
+                    "title": "绑定失败报告",
+                    "target_risks_filter": {},
+                    "custom_prompt": "分析近期高危风险",
+                }
+            )
+
+        self.assertFalse(AnalyseReport.objects.filter(title="绑定失败报告").exists())
+        mock_task.delay.assert_not_called()
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    @mock.patch("services.web.risk.resources.analyse_report.bind_risks_to_analyse_report")
+    def test_generate_report_keeps_bound_snapshot_when_submit_task_failed(self, mock_bind, mock_task):
+        """任务投递失败时报告失败，但创建阶段的风险快照已经完成"""
+        mock_task.delay.side_effect = RuntimeError("connection limit is reached")
+
+        with self.assertRaises(RuntimeError):
+            self.resource.risk.generate_analyse_report(
+                {
+                    "scenario_key": "",
+                    "report_type": AnalyseReportType.CUSTOM,
+                    "title": "投递失败但已绑定",
+                    "target_risks_filter": {},
+                    "custom_prompt": "分析近期高危风险",
+                }
+            )
+
+        report = AnalyseReport.objects.get(title="投递失败但已绑定")
+        self.assertEqual(report.status, AnalyseReportStatus.FAILED)
+        mock_bind.assert_called_once_with(report)
 
     def test_generate_report_serializer_validation(self):
         """测试请求序列化器校验"""
@@ -429,6 +499,104 @@ class TestGenerateAnalyseReport(AnalyseReportTestBase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn("target_risks_filter", serializer.errors)
+
+
+class TestRetryAnalyseReport(AnalyseReportTestBase):
+    """测试手动重试 AI 分析报告"""
+
+    def setUp(self):
+        super().setUp()
+        self.report = AnalyseReport.objects.create(
+            title="可重试报告",
+            report_type=AnalyseReportType.SYSTEM,
+            scenario=self.scenario_person,
+            content="# 旧内容",
+            risk_count=1,
+            status=AnalyseReportStatus.FAILED,
+            task_id="old-task-id",
+            prompt_params={},
+            extra_info={
+                "error": {
+                    "error_type": "Exception",
+                    "error_message": "旧错误",
+                    "retry_count": 2,
+                    "max_retries": 2,
+                }
+            },
+            created_by="admin",
+        )
+        AnalyseReportRisk.objects.create(report=self.report, risk_id=self.risk1.risk_id)
+
+    def test_retry_response_serializer(self):
+        serializer = RetryAnalyseReportResponseSerializer(
+            data={
+                "report_id": self.report.report_id,
+                "task_id": "new-task-id",
+                "status": "PENDING",
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    def test_retry_failed_report_reuses_report_and_keeps_risk_snapshot(self, mock_task):
+        mock_task.delay.return_value.id = "new-task-id"
+
+        result = self.resource.risk.retry_analyse_report.request({"report_id": self.report.report_id})
+
+        self.report.refresh_from_db()
+        self.assertEqual(result["report_id"], self.report.report_id)
+        self.assertEqual(result["task_id"], "new-task-id")
+        self.assertEqual(result["status"], "PENDING")
+        self.assertEqual(self.report.status, AnalyseReportStatus.GENERATING)
+        self.assertEqual(self.report.content, "")
+        self.assertEqual(self.report.task_id, "new-task-id")
+        self.assertEqual(self.report.extra_info, {})
+        self.assertEqual(self.report.risk_count, 1)
+        self.assertEqual(AnalyseReportRisk.objects.filter(report=self.report).count(), 1)
+        mock_task.delay.assert_called_once_with(report_id=self.report.report_id)
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    def test_retry_success_report_is_allowed(self, mock_task):
+        mock_task.delay.return_value.id = "success-retry-task-id"
+        self.report.status = AnalyseReportStatus.SUCCESS
+        self.report.save(update_fields=["status"])
+
+        result = self.resource.risk.retry_analyse_report.request({"report_id": self.report.report_id})
+
+        self.report.refresh_from_db()
+        self.assertEqual(result["task_id"], "success-retry-task-id")
+        self.assertEqual(self.report.status, AnalyseReportStatus.GENERATING)
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    def test_retry_generating_report_is_rejected(self, mock_task):
+        self.report.status = AnalyseReportStatus.GENERATING
+        self.report.save(update_fields=["status"])
+
+        with self.assertRaises(drf_serializers.ValidationError):
+            self.resource.risk.retry_analyse_report.request({"report_id": self.report.report_id})
+
+        mock_task.delay.assert_not_called()
+
+    @mock.patch("services.web.risk.resources.analyse_report.generate_analyse_report")
+    def test_retry_marks_failed_when_submit_task_failed(self, mock_task):
+        mock_task.delay.side_effect = RuntimeError("connection limit is reached")
+
+        with self.assertRaises(RuntimeError):
+            self.resource.risk.retry_analyse_report.request({"report_id": self.report.report_id})
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, AnalyseReportStatus.FAILED)
+        self.assertEqual(self.report.task_id, "")
+        self.assertEqual(self.report.extra_info["error"]["error_type"], "RuntimeError")
+        self.assertEqual(self.report.extra_info["error"]["error_message"], "connection limit is reached")
+
+    def test_retry_route_resolves_to_resource(self):
+        from django.urls import resolve
+
+        match = resolve(f"/api/v1/analyse_report/{self.report.report_id}/retry/")
+
+        self.assertEqual(match.func.actions["post"], "retry")
 
 
 class TestListAnalyseReport(AnalyseReportTestBase):
@@ -1819,19 +1987,20 @@ class TestGenerateAnalyseReportTask(AnalyseReportTestBase):
         self.assertIn("duration_seconds", self.report.extra_info["execution"])
 
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_links_risks_before_chat_completion(self, mock_chat):
-        """调用 Agent 前先关联风险并填充 risk_count"""
-        self.report.risk_count = 0
+    def test_task_uses_existing_risk_count_before_chat_completion(self, mock_chat):
+        """调用 Agent 前使用创建阶段已写入的 risk_count"""
+        self.report.risk_count = 3
         self.report.prompt_params = {"risk_id": self.risk1.risk_id}
         self.report.save(update_fields=["risk_count", "prompt_params"])
 
-        def assert_risk_count_filled(**kwargs):
+        def assert_risk_count_used(**kwargs):
             self.report.refresh_from_db()
-            self.assertEqual(self.report.risk_count, 1)
-            self.assertTrue(AnalyseReportRisk.objects.filter(report=self.report, risk_id=self.risk1.risk_id).exists())
+            self.assertEqual(self.report.risk_count, 3)
+            agent_input = json.loads(kwargs["input"])
+            self.assertEqual(agent_input["已绑定风险数量"], 3)
             return "# 已生成报告"
 
-        mock_chat.side_effect = assert_risk_count_filled
+        mock_chat.side_effect = assert_risk_count_used
 
         from services.web.risk.tasks import generate_analyse_report
 
@@ -1839,7 +2008,7 @@ class TestGenerateAnalyseReportTask(AnalyseReportTestBase):
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, AnalyseReportStatus.SUCCESS)
-        self.assertEqual(self.report.risk_count, 1)
+        self.assertEqual(self.report.risk_count, 3)
 
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
     def test_task_saves_agent_request_before_chat_completion(self, mock_chat):
@@ -2297,9 +2466,9 @@ class TestLinkRisksToReport(AnalyseReportTestBase):
         )
 
     def _call(self, report):
-        from services.web.risk.tasks import _link_risks_to_report
+        from services.web.risk.report.analyse_report import bind_risks_to_analyse_report
 
-        return _link_risks_to_report(report)
+        return bind_risks_to_analyse_report(report)
 
     def test_link_risks_with_matching_params(self):
         """测试根据 prompt_params 关联风险"""
@@ -2546,63 +2715,22 @@ class TestGenerateAnalyseReportTaskLinkRisks(AnalyseReportTestBase):
         )
 
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_creates_report_risk_records(self, mock_chat):
-        """测试任务成功后自动创建 AnalyseReportRisk 关联记录"""
-        mock_chat.return_value = (
-            "# 分析结果\n\n"
-            "## 一、关联风险分析\n\n"
-            "基于风险过滤条件，共发现与张三相关的异常操作风险。\n\n"
-            "## 二、关键发现\n\n"
-            "1. 张三在近30天内的敏感数据访问频次显著高于同岗位平均水平\n"
-            "2. 多次在非授权时间段执行数据导出操作\n\n"
-            "## 三、建议\n\n"
-            "建议加强对张三账号的实时监控，并通知其直属主管进行约谈。\n"
-        )
-
-        from services.web.risk.tasks import generate_analyse_report
-
-        result = generate_analyse_report(report_id=self.report.report_id)
-
-        self.assertEqual(result["report_id"], self.report.report_id)
-        self.report.refresh_from_db()
-        self.assertEqual(self.report.status, AnalyseReportStatus.SUCCESS)
-
-        # 验证 AnalyseReportRisk 关联记录已创建
-        linked_risk_ids = list(AnalyseReportRisk.objects.filter(report=self.report).values_list("risk_id", flat=True))
-        self.assertIn(self.risk1.risk_id, linked_risk_ids)
-        self.assertNotIn(self.risk2.risk_id, linked_risk_ids)
-
-        # 验证 risk_count 已更新
-        self.assertEqual(self.report.risk_count, 1)
-
-    @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_links_all_risks_with_empty_params(self, mock_chat):
-        """测试 prompt_params 为空时关联所有风险"""
-        self.report.prompt_params = {}
-        self.report.save(update_fields=["prompt_params"])
-
-        mock_chat.return_value = (
-            "# 全量风险分析报告\n\n"
-            "## 一、概述\n\n"
-            "本报告对所有风险进行了全面扫描和分类分析。\n\n"
-            "## 二、风险分类统计\n\n"
-            "| 类别 | 数量 | 占比 |\n"
-            "|---|---|---|\n"
-            "| 数据安全 | 15 | 30% |\n"
-            "| 权限管理 | 20 | 40% |\n"
-            "| 异常行为 | 15 | 30% |\n\n"
-            "## 三、建议\n\n"
-            "建议按风险等级优先处理高危事件，加强日常安全巡检。\n"
-        )
+    def test_task_does_not_bind_risks(self, mock_chat):
+        """生成任务只生成内容，不创建报告风险快照"""
+        self.report.risk_count = 7
+        self.report.prompt_params = {"operator": "zhangsan"}
+        self.report.save(update_fields=["risk_count", "prompt_params"])
+        AnalyseReportRisk.objects.filter(report=self.report).delete()
+        mock_chat.return_value = "# 已生成报告"
 
         from services.web.risk.tasks import generate_analyse_report
 
         generate_analyse_report(report_id=self.report.report_id)
 
         self.report.refresh_from_db()
-        linked_count = AnalyseReportRisk.objects.filter(report=self.report).count()
-        self.assertEqual(linked_count, Risk.objects.count())
-        self.assertEqual(self.report.risk_count, Risk.objects.count())
+        self.assertEqual(self.report.status, AnalyseReportStatus.SUCCESS)
+        self.assertEqual(self.report.risk_count, 7)
+        self.assertFalse(AnalyseReportRisk.objects.filter(report=self.report).exists())
 
     @mock.patch("services.web.risk.tasks.generate_analyse_report.retry")
     @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
@@ -2635,74 +2763,6 @@ class TestGenerateAnalyseReportTaskLinkRisks(AnalyseReportTestBase):
         mock_retry.assert_called_once()
         self.report.refresh_from_db()
         self.assertNotEqual(self.report.status, AnalyseReportStatus.SUCCESS)
-
-    @mock.patch("services.web.risk.tasks.logger_celery.error")
-    @mock.patch("services.web.risk.tasks.logger_celery.warning")
-    @mock.patch("services.web.risk.tasks.generate_analyse_report.retry")
-    @mock.patch("services.web.risk.tasks._link_risks_to_report", side_effect=Exception("关联失败"))
-    @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_logs_warning_when_link_fails_before_max_retry(
-        self, mock_chat, mock_link, mock_retry, mock_logger_warning, mock_logger_error
-    ):
-        """未达到最大重试次数时，只记录 warning 并触发重试"""
-        mock_retry.side_effect = RuntimeError("retry called")
-
-        from services.web.risk.tasks import generate_analyse_report
-
-        original_retries = generate_analyse_report.request.retries
-        generate_analyse_report.request.retries = 0
-        try:
-            with self.assertRaisesRegex(RuntimeError, "retry called"):
-                generate_analyse_report(report_id=self.report.report_id)
-        finally:
-            generate_analyse_report.request.retries = original_retries
-
-        mock_chat.assert_not_called()
-        mock_retry.assert_called_once()
-        self.assertEqual(mock_retry.call_args.kwargs["countdown"], 60)
-        self.assertEqual(str(mock_retry.call_args.kwargs["exc"]), "关联失败")
-        mock_logger_warning.assert_called_once()
-        self.assertEqual(
-            mock_logger_warning.call_args.args[0],
-            "[GenerateAnalyseReport] Retrying report_id=%s retries=%s max_retries=%s countdown=%s error=%s",
-        )
-        self.assertTrue(mock_logger_warning.call_args.kwargs["exc_info"])
-        mock_logger_error.assert_not_called()
-
-        self.report.refresh_from_db()
-        self.assertEqual(self.report.status, AnalyseReportStatus.GENERATING)
-
-    @mock.patch("services.web.risk.tasks.logger_celery.error")
-    @mock.patch("services.web.risk.tasks.logger_celery.warning")
-    @mock.patch("services.web.risk.tasks._link_risks_to_report", side_effect=Exception("关联失败"))
-    @mock.patch("services.web.risk.tasks.api.bk_plugins_ai_audit_analyse.chat_completion")
-    def test_task_fails_before_chat_if_link_fails_on_max_retry(
-        self, mock_chat, mock_link, mock_logger_warning, mock_logger_error
-    ):
-        """风险关联失败时不调用 Agent，最终重试失败后记录错误信息"""
-        from services.web.risk.tasks import generate_analyse_report
-
-        original_retries = generate_analyse_report.request.retries
-        generate_analyse_report.request.retries = generate_analyse_report.max_retries
-        try:
-            with self.assertRaisesRegex(Exception, "关联失败"):
-                generate_analyse_report(report_id=self.report.report_id)
-        finally:
-            generate_analyse_report.request.retries = original_retries
-
-        self.report.refresh_from_db()
-        self.assertEqual(self.report.status, AnalyseReportStatus.FAILED)
-        self.assertNotIn("agent_request", self.report.extra_info)
-        self.assertIn("execution", self.report.extra_info)
-        self.assertEqual(self.report.extra_info["error"]["error_message"], "关联失败")
-        mock_chat.assert_not_called()
-        mock_logger_warning.assert_not_called()
-        mock_logger_error.assert_called_once()
-        self.assertEqual(
-            mock_logger_error.call_args.args[0],
-            "[GenerateAnalyseReport] Max retries reached report_id=%s retries=%s max_retries=%s",
-        )
-        self.assertEqual(str(mock_logger_error.call_args.kwargs["exc_info"][1]), "关联失败")
 
 
 class TestAnalyseReportAdmin(AnalyseReportTestBase):

--- a/src/backend/tests/test_risk/test_export_task.py
+++ b/src/backend/tests/test_risk/test_export_task.py
@@ -112,11 +112,11 @@ class TestRiskExportTask(TestCase):
         mock_update_state.assert_any_call(state="RUNNING", meta={"current": 0, "total": 2})
         mock_update_state.assert_any_call(state="PROGRESS", meta={"current": 2, "total": 2})
 
-    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.report")
+    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.async_report")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.update_state")
     @mock.patch("services.web.risk.tasks.RiskExportService")
     def test_export_risks_to_mail_apply_returns_failure_state_after_max_retry(
-        self, mock_service_cls, mock_update_state, mock_report_event
+        self, mock_service_cls, mock_update_state, mock_async_report_event
     ):
         service = mock_service_cls.return_value
         service.build_export_file.side_effect = RuntimeError("export failed")
@@ -135,14 +135,14 @@ class TestRiskExportTask(TestCase):
         self.assertEqual(result.state, "FAILURE")
         self.assertIsInstance(result.result, RuntimeError)
         self.assertIn("export failed", str(result.result))
-        mock_report_event.assert_called_once()
+        mock_async_report_event.assert_called_once()
 
-    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.report")
+    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.async_report")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.retry")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.update_state")
     @mock.patch("services.web.risk.tasks.RiskExportService")
     def test_export_risks_to_mail_retries_when_send_mail_failed(
-        self, mock_service_cls, mock_update_state, mock_retry, mock_report_event
+        self, mock_service_cls, mock_update_state, mock_retry, mock_async_report_event
     ):
         mock_retry.side_effect = RuntimeError("retry called")
         service = mock_service_cls.return_value
@@ -166,16 +166,24 @@ class TestRiskExportTask(TestCase):
             requested_at="2026-06-22 19:33:36",
         )
         mock_retry.assert_called_once_with(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
-        mock_report_event.assert_not_called()
+        mock_async_report_event.assert_not_called()
 
     @mock.patch("services.web.risk.tasks.logger_celery.error")
     @mock.patch("services.web.risk.tasks.logger_celery.warning")
-    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.report")
+    @mock.patch("services.web.risk.tasks.report_observation_metric")
+    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.async_report")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.retry")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.update_state")
     @mock.patch("services.web.risk.tasks.RiskExportService")
     def test_export_risks_to_mail_retries_before_max_retry(
-        self, mock_service_cls, mock_update_state, mock_retry, mock_report_event, mock_logger_warning, mock_logger_error
+        self,
+        mock_service_cls,
+        mock_update_state,
+        mock_retry,
+        mock_async_report_event,
+        mock_report_metric,
+        mock_logger_warning,
+        mock_logger_error,
     ):
         mock_retry.side_effect = RuntimeError("retry called")
         service = mock_service_cls.return_value
@@ -195,7 +203,8 @@ class TestRiskExportTask(TestCase):
             export_risks_to_mail.request.retries = original_retries
 
         mock_retry.assert_called_once_with(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
-        mock_report_event.assert_not_called()
+        mock_async_report_event.assert_not_called()
+        mock_report_metric.assert_not_called()
         warning_messages = [call.args[0] for call in mock_logger_warning.call_args_list]
         error_messages = [call.args[0] for call in mock_logger_error.call_args_list]
         self.assertIn(
@@ -204,13 +213,13 @@ class TestRiskExportTask(TestCase):
         )
         self.assertNotIn("[RiskExportTaskFailed] username=%s total=%s retries=%s max_retries=%s", error_messages)
 
-    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.report")
+    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.async_report")
     @mock.patch("services.web.risk.tasks.logger_celery.error")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.retry")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.update_state")
     @mock.patch("services.web.risk.tasks.RiskExportService")
     def test_export_risks_to_mail_reports_alert_after_max_retry(
-        self, mock_service_cls, mock_update_state, mock_retry, mock_logger_error, mock_report_event
+        self, mock_service_cls, mock_update_state, mock_retry, mock_logger_error, mock_async_report_event
     ):
         mock_retry.side_effect = MaxRetriesExceededError()
         service = mock_service_cls.return_value
@@ -224,7 +233,7 @@ class TestRiskExportTask(TestCase):
                 requested_at="2026-06-22 19:33:36",
             )
 
-        mock_report_event.assert_called_once()
+        mock_async_report_event.assert_called_once()
         mock_retry.assert_called_once_with(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
         error_messages = [call.args[0] for call in mock_logger_error.call_args_list]
         self.assertIn(
@@ -232,15 +241,15 @@ class TestRiskExportTask(TestCase):
             error_messages,
         )
 
-    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.report")
+    @mock.patch("services.web.risk.tasks.report_observation_metric")
+    @mock.patch("services.web.risk.tasks.RiskExportFailedEvent.async_report")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.retry")
     @mock.patch("services.web.risk.tasks.export_risks_to_mail.update_state")
     @mock.patch("services.web.risk.tasks.RiskExportService")
-    def test_export_risks_to_mail_keeps_original_error_when_report_failed(
-        self, mock_service_cls, mock_update_state, mock_retry, mock_report_event
+    def test_export_risks_to_mail_reports_event_and_keeps_original_error(
+        self, mock_service_cls, mock_update_state, mock_retry, mock_async_report_event, mock_report_metric
     ):
         mock_retry.side_effect = MaxRetriesExceededError()
-        mock_report_event.side_effect = RuntimeError("report failed")
         service = mock_service_cls.return_value
         service.build_export_file.side_effect = RuntimeError("export failed")
 
@@ -252,5 +261,12 @@ class TestRiskExportTask(TestCase):
                 requested_at="2026-06-22 19:33:36",
             )
 
-        mock_report_event.assert_called_once()
+        mock_async_report_event.assert_called_once()
         mock_retry.assert_called_once_with(countdown=settings.RISK_EXPORT_TASK_RETRY_DELAY)
+        mock_report_metric.assert_called_once()
+        metric_kwargs = mock_report_metric.call_args.kwargs
+        self.assertEqual(metric_kwargs["name"], "risk.export_risks_to_mail")
+        self.assertEqual(metric_kwargs["status"], "error")
+        self.assertEqual(metric_kwargs["error_type"], "RuntimeError")
+        self.assertEqual(metric_kwargs["dimensions"]["operation"], "export_risks_to_mail")
+        self.assertEqual(metric_kwargs["dimensions"]["business_status"], "failed")

--- a/src/backend/tests/test_risk/test_nl2riskfilter.py
+++ b/src/backend/tests/test_risk/test_nl2riskfilter.py
@@ -6,6 +6,7 @@ NL2Risk 序列化器及工具函数单测
 import datetime
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils import timezone
 
 from services.web.risk.constants import NL2RiskFilterLogStatus
@@ -552,6 +553,69 @@ class NL2RiskFilterWithLoggingTest(TestCase):
         call_kwargs = mock_save_log.call_args[1]
         self.assertEqual(call_kwargs["status"], NL2RiskFilterLogStatus.API_ERROR)
         self.assertIn("Connection refused", call_kwargs["error_message"])
+
+    @patch("services.web.risk.resources.risk.NL2RiskFilterFailedEvent")
+    @patch("services.web.risk.resources.risk.NL2RiskFilterLog.save_nl2risk_filter_log")
+    @patch("services.web.risk.resources.risk.get_request_username", return_value="admin")
+    @patch("services.web.risk.resources.risk.api.bk_plugins_ai_agent.chat_completion")
+    def test_api_error_reports_custom_event(self, mock_chat, mock_user, mock_save_log, mock_event_cls):
+        """AI 平台异常时上报自定义事件"""
+        mock_chat.side_effect = Exception("Connection refused")
+        mock_event = mock_event_cls.return_value
+
+        with self.assertRaises(NL2RiskFilterServiceError):
+            self.resource.request({"query": "测试", "tags": [], "strategies": []})
+
+        mock_event_cls.assert_called_once()
+        event_kwargs = mock_event_cls.call_args.kwargs
+        self.assertEqual(event_kwargs["target"], "nl2risk_filter")
+        self.assertEqual(event_kwargs["context"]["status"], NL2RiskFilterLogStatus.API_ERROR)
+        self.assertEqual(event_kwargs["context"]["error_type"], "Exception")
+        mock_event.async_report.assert_called_once()
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=123, LOG_EXPORT_STATUS_ACCESS_TOKEN="token")
+    @patch("core.monitor.report_metric_to_bk_monitor.delay")
+    @patch("services.web.risk.resources.risk.NL2RiskFilterLog.save_nl2risk_filter_log")
+    @patch("services.web.risk.resources.risk.get_request_username", return_value="admin")
+    @patch("services.web.risk.resources.risk.api.bk_plugins_ai_agent.chat_completion")
+    def test_success_reports_business_metric(self, mock_chat, mock_user, mock_save_log, mock_delay):
+        """成功生成筛选条件时上报业务调用量和耗时指标"""
+        mock_chat.return_value = '{"filter_conditions": {"level": "high"}}'
+
+        self.resource.request({"query": "高危风险", "tags": [], "strategies": []})
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        self.assertEqual(payload["data_id"], 123)
+        data = payload["data"][0]
+        self.assertEqual(data["metrics"]["call_count"], 1)
+        self.assertGreaterEqual(data["metrics"]["duration_ms"], 0)
+        self.assertEqual(data["dimension"]["service"], "risk")
+        self.assertEqual(data["dimension"]["operation"], "nl2risk_filter")
+        self.assertEqual(data["dimension"]["status"], "success")
+        self.assertEqual(data["dimension"]["business_status"], NL2RiskFilterLogStatus.SUCCESS)
+
+    @override_settings(LOG_EXPORT_STATUS_DATA_ID=123, LOG_EXPORT_STATUS_ACCESS_TOKEN="token")
+    @patch("core.monitor.report_metric_to_bk_monitor.delay")
+    @patch("services.web.risk.resources.risk.NL2RiskFilterLog.save_nl2risk_filter_log")
+    @patch("services.web.risk.resources.risk.get_request_username", return_value="admin")
+    @patch("services.web.risk.resources.risk.api.bk_plugins_ai_agent.chat_completion")
+    def test_parse_failed_reports_error_business_metric(self, mock_chat, mock_user, mock_save_log, mock_delay):
+        """AI 返回不可解析内容时计入业务错误率"""
+        mock_chat.return_value = "抱歉，我无法理解您的查询"
+
+        self.resource.request({"query": "无效查询", "tags": [], "strategies": []})
+
+        mock_delay.assert_called_once()
+        payload = mock_delay.call_args[0][0]
+        data = payload["data"][0]
+        self.assertEqual(data["metrics"]["call_count"], 1)
+        self.assertGreaterEqual(data["metrics"]["duration_ms"], 0)
+        self.assertEqual(data["dimension"]["service"], "risk")
+        self.assertEqual(data["dimension"]["operation"], "nl2risk_filter")
+        self.assertEqual(data["dimension"]["status"], "error")
+        self.assertEqual(data["dimension"]["business_status"], NL2RiskFilterLogStatus.PARSE_FAILED)
+        self.assertEqual(data["dimension"]["error_type"], NL2RiskFilterLogStatus.PARSE_FAILED)
 
 
 class ListNL2RiskFilterLogRequestSerializerTest(TestCase):

--- a/src/backend/tests/test_strategy_v2/test_strategy_resources.py
+++ b/src/backend/tests/test_strategy_v2/test_strategy_resources.py
@@ -10,11 +10,14 @@ from unittest import mock
 from django.core.cache import cache, caches
 from django.test import override_settings
 from iam.eval.constants import KEYWORD_BK_IAM_PATH
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
 
 from apps.meta.constants import ConfigLevelChoices
 from apps.meta.models import GlobalMetaConfig, Tag
 from apps.meta.utils.fields import EXTEND_DATA, SNAPSHOT_USER_INFO
 from apps.permission.handlers.resource_types import ResourceEnum
+from core.observability import start_observation_span
 from services.web.databus.constants import COLLECTOR_PLUGIN_ID
 from services.web.databus.models import CollectorPlugin
 from services.web.scene.constants import (
@@ -284,6 +287,44 @@ class StrategyResourcesTest(TestCase):
         )
         self.assertEqual(result["managers"], ["tom"])
         self.assertEqual(result["formatted_fields"], [{"field_name": "formatted"}])
+
+    @mock.patch("services.web.strategy_v2.resources.enhance_rt_fields")
+    @mock.patch.object(GetRTMeta, "get_sensitivity_info")
+    @mock.patch.object(GetRTMeta, "get_data_manager")
+    @mock.patch.object(GetRTMeta, "get_meta")
+    def test_get_rt_meta_thread_pool_preserves_otel_context(
+        self,
+        mock_get_meta,
+        mock_get_data_manager,
+        mock_get_sensitivity_info,
+        mock_enhance_fields,
+    ):
+        provider = TracerProvider()
+        seen_span_ids = []
+
+        def capture_current_span(result):
+            seen_span_ids.append(trace.get_current_span().get_span_context().span_id)
+            return result
+
+        mock_get_meta.side_effect = lambda table_id: capture_current_span(
+            {"fields": [{"field_name": table_id, "field_alias": "RT", "field_type": "string"}]}
+        )
+        mock_get_data_manager.side_effect = lambda table_id: capture_current_span(
+            {"managers": [table_id], "viewers": []}
+        )
+        mock_get_sensitivity_info.side_effect = lambda table_id: capture_current_span(
+            {"sensitivity_info": {"level": table_id}}
+        )
+        mock_enhance_fields.return_value = [{"field_name": "formatted"}]
+
+        with mock.patch("core.observability.trace.get_tracer_provider", return_value=provider):
+            with start_observation_span("strategy.get_rt_meta") as parent_span:
+                parent_span_id = parent_span.get_span_context().span_id
+                result = GetRTMeta().perform_request({"table_id": "rt"})
+
+        self.assertEqual(result["formatted_fields"], [{"field_name": "formatted"}])
+        self.assertEqual(len(seen_span_ids), 3)
+        self.assertTrue(all(span_id == parent_span_id for span_id in seen_span_ids))
 
     @mock.patch("services.web.strategy_v2.resources.enhance_rt_fields")
     @mock.patch.object(GetRTMeta, "get_sensitivity_info")


### PR DESCRIPTION
- 新增报告重试接口，支持成功和失败报告复用原记录与风险快照重新生成
- 将报告风险快照绑定前移至创建事务，任务层仅负责内容生成和自身异常重试
- 补充报告创建、重试状态流转、投递失败和任务侧不重复绑定等回归测试