### PR TITLE
feat: 审计风险列表待我处理、我的关注列表优化 --story=135733704

### DIFF
--- a/src/backend/services/web/risk/resources/risk.py
+++ b/src/backend/services/web/risk/resources/risk.py
@@ -870,7 +870,7 @@ class ListNoticingRisk(ListRisk):
     def load_risks(self, validated_request_data, username: str = None):
         username = username or get_request_username()
         q = self._build_filter_query(validated_request_data)
-        # 个人视图只需查询窗口内新授权的工单权限，减少历史权限扫描量。
+        # 我的关注以 TicketPermission(notice_user) 为事实表，notice_users 仅作为生成授权的来源数据。
         event_time_start = next(iter(validated_request_data.get("event_time__gte") or []), None)
         return Risk.objects.filter(
             q,
@@ -879,7 +879,6 @@ class ListNoticingRisk(ListRisk):
                 username=username,
                 authorized_at_start=event_time_start,
             ),
-            notice_users__contains=username,
         ).distinct()
 
 

--- a/src/backend/tests/test_risk/test_retrieve_risk.py
+++ b/src/backend/tests/test_risk/test_retrieve_risk.py
@@ -1487,7 +1487,7 @@ class TestListMineAndNoticingRisk(TestCase):
         self.assertNotIn(self.risk_operator_permission_but_not_current.risk_id, risk_ids)
 
     def test_list_noticing_risk_no_perm_check(self):
-        """ListNoticingRisk 不依赖 load_authed_risks，按本地工单权限查询"""
+        """ListNoticingRisk 不依赖 load_authed_risks，以本地关注权限为事实表"""
         from services.web.risk.resources.risk import ListNoticingRisk
 
         request = self._make_request()
@@ -1496,9 +1496,9 @@ class TestListMineAndNoticingRisk(TestCase):
         results = response["results"]
         risk_ids = {item["risk_id"] for item in results}
         self.assertIn(self.risk_noticed.risk_id, risk_ids)
+        self.assertIn(self.risk_notice_permission_but_not_noticed.risk_id, risk_ids)
         self.assertNotIn(self.risk_owned.risk_id, risk_ids)
         self.assertNotIn(self.risk_noticed_without_permission.risk_id, risk_ids)
-        self.assertNotIn(self.risk_notice_permission_but_not_noticed.risk_id, risk_ids)
 
     def test_list_noticing_risk_filters_permission_by_start_time(self):
         """关注风险按查询开始时间收敛本地权限范围。"""
@@ -1640,7 +1640,8 @@ class TestListMineAndNoticingRisk(TestCase):
             _request=request,
         )
         ids = [r["risk_id"] for r in response["results"]]
-        self.assertEqual(ids[0], self.risk_noticed.risk_id)
+        self.assertEqual(ids[0], self.risk_notice_permission_but_not_noticed.risk_id)
+        self.assertIn(self.risk_noticed.risk_id, ids)
 
     def test_list_noticing_risk_multi_sort_event_time_desc_risk_id_desc(self):
         """我的关注: sort=['-event_time', '-risk_id']"""
@@ -1653,7 +1654,14 @@ class TestListMineAndNoticingRisk(TestCase):
             _request=request,
         )
         ids = [r["risk_id"] for r in response["results"]]
-        self.assertEqual(ids, [risk_owned_low.risk_id, self.risk_noticed.risk_id])
+        self.assertEqual(
+            ids,
+            [
+                self.risk_notice_permission_but_not_noticed.risk_id,
+                risk_owned_low.risk_id,
+                self.risk_noticed.risk_id,
+            ],
+        )
 
     # ──── load_risks ────
 


### PR DESCRIPTION
1. 我的关注以 TicketPermission(notice_user) 为事实表，notice_users 仅作为生成授权的来源数据。