### PR TITLE
fix: 审计 IAMV4 权限迁移-修复策略字段值孤儿系统异常 --story=1069990729135791617

### DIFF
--- a/src/backend/apps/meta/handlers/system_sync.py
+++ b/src/backend/apps/meta/handlers/system_sync.py
@@ -253,7 +253,8 @@ class IamSystemSyncer(abc.ABC):
 
         if to_delete:
             # 删除系统同时需要删除其下的资源
-            System.objects.filter(source_type=self.source_type, instance_id__in=to_delete).delete()
+            for system in System.objects.filter(source_type=self.source_type, instance_id__in=to_delete):
+                system.delete()
 
         logger.info(f"[{self.cls_name}] finished")
 

--- a/src/backend/apps/meta/models.py
+++ b/src/backend/apps/meta/models.py
@@ -292,12 +292,24 @@ class System(OperateRecordModel):
             self.system_id = self.build_system_id(self.source_type, self.instance_id)
         super().save(*args, **kwargs)
 
+    def delete_related_resources(self):
+        """
+        清理通过 system_id 字符串关联的资源和操作。
+        """
+
+        for resource_type in ResourceType.objects.filter(system_id=self.system_id):
+            resource_type.delete()
+        for action in Action.objects.filter(system_id=self.system_id):
+            action.delete()
+        ResourceTypeActionRelation.objects.filter(system_id=self.system_id).delete()
+
     @transaction.atomic
     def delete(self, *args, **kwargs):
         """
         删除系统及其资源
         """
 
+        self.delete_related_resources()
         SystemRole.objects.filter(system_id=self.system_id).delete()
         SystemDiagnosisConfig.objects.filter(system_id=self.system_id).delete()
         SystemFavorite.objects.filter(system_id=self.system_id).delete()

--- a/src/backend/services/web/strategy_v2/utils/field_value.py
+++ b/src/backend/services/web/strategy_v2/utils/field_value.py
@@ -110,15 +110,27 @@ class FieldValueHandler:
     def _db_data_with_system_to_list(
         self, data: QuerySet, get_id: callable = lambda item: item.id, get_name: callable = lambda item: item.name
     ) -> List[dict]:
+        systems = list(System.objects.filter(namespace=self.namespace))
+        system_ids = [system.system_id for system in systems]
         data_map = {
             system.system_id: {
                 self.label_key: f"{system.name}({system.system_id})",
                 self.value_key: system.system_id,
                 "children": [],
             }
-            for system in System.objects.all()
+            for system in systems
         }
-        for instance in data:
+        missing_system_ids = list(
+            data.exclude(system_id__in=system_ids).values_list("system_id", flat=True).distinct().order_by("system_id")
+        )
+        if missing_system_ids:
+            logger.warning(
+                "[FieldValueHandlerMissingSystem] Field => %s; Namespace => %s; SystemIDs => %s",
+                self.field_name,
+                self.namespace,
+                missing_system_ids,
+            )
+        for instance in data.filter(system_id__in=system_ids):
             data_map[instance.system_id]["children"].append(
                 {self.value_key: get_id(instance), self.label_key: get_name(instance)}
             )

--- a/src/backend/tests/test_meta/test_tasks/test_sync_iam_systems.py
+++ b/src/backend/tests/test_meta/test_tasks/test_sync_iam_systems.py
@@ -21,7 +21,7 @@ import pytest
 from blueapps.core.celery import celery_app
 
 from apps.meta.constants import SystemSourceTypeEnum
-from apps.meta.models import Action, ResourceType, System
+from apps.meta.models import Action, ResourceType, ResourceTypeActionRelation, System
 from apps.meta.tasks import sync_iam_systems, sync_system_paas_info
 from core.testing import assert_list_contains
 from tests.base import TestCase
@@ -127,3 +127,26 @@ class TestSyncIamSystems(TestCase):
         self.sync_system()
         system.refresh_from_db()
         self.assertEqual(system.managers, ["modify_manager"])
+
+    def test_sync_systems_deletes_related_resources_and_actions(self):
+        """同步删除下线系统时同步清理其资源、操作和关联关系"""
+        stale_system = System.objects.create(
+            namespace=self.namespace,
+            source_type=SystemSourceTypeEnum.IAM_V4.value,
+            instance_id="cmdb_inspection",
+            name="CMDB 巡检",
+        )
+        ResourceType.objects.create(system_id=stale_system.system_id, resource_type_id="biz", name="业务")
+        Action.objects.create(system_id=stale_system.system_id, action_id="view_biz", name="查看业务")
+        ResourceTypeActionRelation.objects.create(
+            system_id=stale_system.system_id,
+            resource_type_id="biz",
+            action_id="view_biz",
+        )
+
+        self.sync_system()
+
+        self.assertFalse(System.objects.filter(system_id=stale_system.system_id).exists())
+        self.assertFalse(ResourceType.objects.filter(system_id=stale_system.system_id).exists())
+        self.assertFalse(Action.objects.filter(system_id=stale_system.system_id).exists())
+        self.assertFalse(ResourceTypeActionRelation.objects.filter(system_id=stale_system.system_id).exists())

--- a/src/backend/tests/test_strategy_v2/test_field_value.py
+++ b/src/backend/tests/test_strategy_v2/test_field_value.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - 审计中心 (BlueKing - Audit Center) available.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from apps.meta.constants import SystemSourceTypeEnum
+from apps.meta.models import Action, ResourceType, System
+from services.web.strategy_v2.resources import GetStrategyFieldValue
+from services.web.strategy_v2.utils.field_value import FieldValueHandler
+from tests.base import TestCase
+
+
+class FieldValueHandlerTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.system = System.objects.create(
+            namespace=self.namespace,
+            system_id="bk_valid",
+            source_type=SystemSourceTypeEnum.IAM_V3.value,
+            instance_id="bk_valid",
+            name="有效系统",
+        )
+        ResourceType.objects.create(system_id=self.system.system_id, resource_type_id="host", name="主机")
+        Action.objects.create(system_id=self.system.system_id, action_id="view_host", name="查看主机")
+
+        ResourceType.objects.create(
+            system_id="iam_v4_cmdb_inspection",
+            resource_type_id="biz",
+            name="业务",
+        )
+        Action.objects.create(
+            system_id="iam_v4_cmdb_inspection",
+            action_id="view_biz",
+            name="查看业务",
+        )
+
+    @staticmethod
+    def _child_values(values):
+        return {child["value"] for group in values for child in group.get("children", [])}
+
+    def test_resource_type_field_value_skips_orphan_system_data(self):
+        values = FieldValueHandler(field_name="resource_type_id", namespace=self.namespace).values
+
+        self.assertIn("host", self._child_values(values))
+        self.assertNotIn("biz", self._child_values(values))
+
+    def test_action_field_value_skips_orphan_system_data(self):
+        values = FieldValueHandler(field_name="action_id", namespace=self.namespace).values
+
+        self.assertIn("view_host", self._child_values(values))
+        self.assertNotIn("view_biz", self._child_values(values))
+
+    @mock.patch("services.web.strategy_v2.resources.get_local_request")
+    @mock.patch("services.web.strategy_v2.resources.ActionPermission")
+    def test_get_strategy_field_value_request_skips_orphan_system_data(
+        self,
+        mock_action_permission,
+        mock_get_local_request,
+    ):
+        mock_action_permission.return_value.has_permission.return_value = True
+        mock_get_local_request.return_value = SimpleNamespace(
+            COOKIES={"bk_token": "fake"},
+            user=SimpleNamespace(username="tester"),
+        )
+
+        values = GetStrategyFieldValue().request(
+            {
+                "namespace": self.namespace,
+                "field_name": "resource_type_id",
+            }
+        )
+
+        self.assertIn("host", self._child_values(values))
+        self.assertNotIn("biz", self._child_values(values))


### PR DESCRIPTION
- 修复策略字段值接口遇到孤儿系统资源数据时返回 500 的问题

- 系统下线同步时清理资源、操作和资源操作关系，避免再次产生孤儿数据

- 补充字段值接口和 IAM 同步删除回归测试