### PR TITLE
fix: Windows 环境执行 python manage.py test 单测报错修复

### DIFF
--- a/src/backend/core/exporter/export.py
+++ b/src/backend/core/exporter/export.py
@@ -17,7 +17,7 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import abc
-import tempfile
+import io
 
 import xlsxwriter
 from django.core.files import File
@@ -27,8 +27,10 @@ class BaseXlsxFileExporter(abc.ABC):
     """文件导出器基类"""
 
     def __init__(self, *args, **kwargs):
-        self.tmp_file = tempfile.NamedTemporaryFile(delete=True, suffix=self.suffix)
-        self.workbook = xlsxwriter.Workbook(self.tmp_file.name, {'constant_memory': True})
+        # 使用内存字节流, 规避 Windows 上 NamedTemporaryFile 句柄冲突
+        # BytesIO 同时也是 xlsxwriter 官方推荐的 file-like 输出方式 (无磁盘 IO)
+        self.tmp_file = io.BytesIO()
+        self.workbook = xlsxwriter.Workbook(self.tmp_file, {'constant_memory': True})
 
     @property
     @abc.abstractmethod

--- a/src/backend/services/web/risk/resources/analyse_report.py
+++ b/src/backend/services/web/risk/resources/analyse_report.py
@@ -20,6 +20,7 @@ import abc
 import io
 import logging
 import os
+import re
 import uuid
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -594,17 +595,22 @@ class ExportAnalyseReport(AnalyseReportMeta):
         if not uri:
             return cls._BLOCKED_PDF_RESOURCE_URI
 
-        parsed_uri = urlparse(uri)
-        if parsed_uri.scheme in {"http", "https", "data"}:
-            return uri
-        if parsed_uri.scheme == "file":
-            candidate_path = unquote(parsed_uri.path)
-        elif parsed_uri.scheme:
-            return cls._BLOCKED_PDF_RESOURCE_URI
-        elif os.path.isabs(uri):
+        # Windows 盘符路径 (如 C:\xxx.ttf): 跳过 urlparse, 避免 scheme="c" 误判
+        # 用正则模式统一处理, Linux 上永远不会命中 (没有盘符路径)
+        if re.match(r"^[a-zA-Z]:[\\/]", uri):
             candidate_path = uri
         else:
-            candidate_path = os.path.join(os.path.dirname(rel), uri) if rel else os.path.abspath(uri)
+            parsed_uri = urlparse(uri)
+            if parsed_uri.scheme in {"http", "https", "data"}:
+                return uri
+            if parsed_uri.scheme == "file":
+                candidate_path = unquote(parsed_uri.path)
+            elif parsed_uri.scheme:
+                return cls._BLOCKED_PDF_RESOURCE_URI
+            elif os.path.isabs(uri):
+                candidate_path = uri
+            else:
+                candidate_path = os.path.join(os.path.dirname(rel), uri) if rel else os.path.abspath(uri)
 
         builtin_font_path = os.path.realpath(cls._CJK_FONT_PATH)
         if os.path.realpath(candidate_path) == builtin_font_path:

--- a/src/backend/tests/test_bk_plugins/test_ai_audit_report.py
+++ b/src/backend/tests/test_bk_plugins/test_ai_audit_report.py
@@ -17,6 +17,8 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import json
+import sys
+import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -738,3 +740,29 @@ class TestAIAuditReportAPIGWConfig(TestCase):
         self.assertIn("event_data", detail_properties)
         self.assertIn("has_report", detail_properties)
         self.assertNotIn("report", detail_properties)
+
+    def test_yaml_read_with_utf8_encoding_succeeds(self):
+        """L1: 验证 read_text(encoding="utf-8") 修复 - 显式传 encoding 后能正确解析 yaml
+
+        修复前: read_text() 走系统默认编码, Windows 上 GBK 解析 UTF-8 YAML 失败
+        修复后: 显式传 encoding="utf-8", 任何平台都能正确解析
+        """
+        yaml_path = BACKEND_DIR / "support-files/apigw/definition.yaml"
+        # 模拟修复后代码的调用方式: 显式传 encoding
+        content = yaml_path.read_text(encoding="utf-8")
+        # 验证读到非空字符串, 包含 list_analyse_report_risk_apigw (说明 UTF-8 解析成功)
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 0)
+        self.assertIn("list_analyse_report_risk_apigw", content)
+
+    @unittest.skipUnless(sys.platform == "win32", "仅在 Windows 真实环境验证 GBK 默认编码修复")
+    def test_yaml_default_encoding_raises_on_windows(self):
+        """L2a: 反例验证 - Windows 上不传 encoding 走系统默认 GBK, 解析 UTF-8 YAML 会 UnicodeDecodeError
+
+        修复前: read_text() 走系统默认编码 (Windows=GBK), 解析 UTF-8 YAML 失败
+        修复后: 显式传 encoding="utf-8", 修复代码不会再现此问题
+        本测试: 故意不传 encoding, 验证 Windows 上确实会失败 (作为修复基线)
+        """
+        yaml_path = BACKEND_DIR / "support-files/apigw/definition.yaml"
+        with self.assertRaises(UnicodeDecodeError):
+            yaml_path.read_text()  # 不传 encoding, Windows 默认 GBK

--- a/src/backend/tests/test_bk_plugins/test_ai_audit_report.py
+++ b/src/backend/tests/test_bk_plugins/test_ai_audit_report.py
@@ -717,13 +717,13 @@ class TestAIAuditReportAPIGWConfig(TestCase):
     """测试 AI 审计报告 APIGW/MCP 配置"""
 
     def test_audit_report_mcp_uses_report_risk_resource(self):
-        definition = (BACKEND_DIR / "support-files/apigw/definition.yaml").read_text()
+        definition = (BACKEND_DIR / "support-files/apigw/definition.yaml").read_text(encoding="utf-8")
 
         self.assertIn("list_analyse_report_risk_apigw", definition)
         self.assertNotIn("list_risk_apigw", definition)
 
     def test_report_risk_apigw_resource_defined(self):
-        resources = yaml.safe_load((BACKEND_DIR / "support-files/apigw/resources.yaml").read_text())
+        resources = yaml.safe_load((BACKEND_DIR / "support-files/apigw/resources.yaml").read_text(encoding="utf-8"))
         resource = resources["paths"]["/analyse_report_apigw/{report_id}/risks/"]["post"]
 
         self.assertEqual(resource["operationId"], "list_analyse_report_risk_apigw")

--- a/src/backend/tests/test_core/test_exporter.py
+++ b/src/backend/tests/test_core/test_exporter.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - 审计中心 (BlueKing - Audit Center) available.
+Copyright (C) 2023 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+import io
+import sys
+import unittest
+from unittest import mock
+
+import openpyxl
+
+from core.exporter import export as exporter_module
+from core.exporter.export import BaseXlsxFileExporter
+from services.web.risk.handlers.risk_export import MultiSheetRiskExporterXlsx
+from tests.base import TestCase
+
+
+class _MinimalExporter(BaseXlsxFileExporter):
+    """最小化具体子类, 仅用于直接测试 BaseXlsxFileExporter 自身行为"""
+
+    suffix = "xlsx"
+
+    def write(self):
+        pass
+
+
+class TestBaseXlsxFileExporter(TestCase):
+    """L1 (代码契约, 任何平台跑): 验证 BaseXlsxFileExporter 行为符合预期, 防止回退到 NamedTemporaryFile"""
+
+    def _make_exporter(self):
+        return _MinimalExporter()
+
+    def test_init_uses_in_memory_bytes_io(self):
+        """验证 __init__ 使用 io.BytesIO, 不是 NamedTemporaryFile (跨平台修复核心)"""
+        exporter = self._make_exporter()
+        self.assertIsInstance(exporter.tmp_file, io.BytesIO)
+
+    def test_save_returns_django_file_with_valid_xlsx(self):
+        """验证 save() 返回的 File 内容是有效 xlsx (zip 格式, 头 2 字节 PK)"""
+        exporter = self._make_exporter()
+        sheet = exporter.workbook.add_worksheet("test")
+        sheet.write_row(0, 0, ["col1", "col2"])
+        sheet.write_row(1, 0, ["a", "b"])
+
+        file = exporter.save()
+        content = file.read()
+
+        self.assertTrue(
+            content.startswith(b"PK"),
+            f"xlsx file should start with PK (zip header), got {content[:10]!r}",
+        )
+
+    def test_save_resets_file_pointer_to_start(self):
+        """验证 save() 后能 seek(0) 读到全部字节, 防止指针错位"""
+        exporter = self._make_exporter()
+        sheet = exporter.workbook.add_worksheet("test")
+        sheet.write_row(0, 0, ["col1"])
+        sheet.write_row(1, 0, ["data"])
+
+        file = exporter.save()
+        first_read = file.read()
+        self.assertTrue(first_read.startswith(b"PK"))
+
+        # 关键: save() 内部应执行 seek(0), 二次 read 仍能从头读
+        file.seek(0)
+        second_read = file.read()
+        self.assertEqual(first_read, second_read)
+
+    def test_close_is_idempotent(self):
+        """验证 close() 二次调用不抛 ValueError, 防止 Windows 句柄已关闭后再 close"""
+        exporter = self._make_exporter()
+        exporter.close()
+        # 二次 close 必须幂等, 不能抛 "I/O operation on closed file"
+        exporter.close()
+
+    def test_uses_constant_memory_option(self):
+        """验证 xlsxwriter 创建时使用 constant_memory: True (大文件内存优化)"""
+        with mock.patch.object(exporter_module.xlsxwriter, "Workbook") as mock_wb:
+            mock_wb.return_value = mock.MagicMock()
+            self._make_exporter()
+
+            self.assertEqual(mock_wb.call_args.args[1], {"constant_memory": True})
+
+    def test_concrete_subclass_save_writes_valid_xlsx(self):
+        """端到端验证: 用真实子类 MultiSheetRiskExporterXlsx 实例化 + save, 用 openpyxl 读出有效 xlsx"""
+        exporter = MultiSheetRiskExporterXlsx()
+        file = exporter.save()
+
+        workbook = openpyxl.load_workbook(io.BytesIO(file.read()))
+        # 至少 workbook 可被 openpyxl 解析, 证明 xlsx 字节流格式正确
+        self.assertIsNotNone(workbook)
+
+
+class TestBaseXlsxFileExporterWindowsOnly(unittest.TestCase):
+    """L2a (仅 Windows 真实环境跑): 验证 Windows 上不再报 NamedTemporaryFile 句柄冲突"""
+
+    @unittest.skipUnless(sys.platform == "win32", "仅在 Windows 验证 NamedTemporaryFile 句柄冲突修复")
+    def test_concurrent_multi_sheet_export_no_handle_conflict(self):
+        """真实 Windows: 连续 5 次实例化 MultiSheetRiskExporterXlsx 并 save + read, 不报 PermissionError
+
+        修复前: Windows 上 NamedTemporaryFile 句柄未释放, 第 2 次 save 报
+                "PermissionError: [WinError 32] 另一个程序正在使用此文件"
+        修复后: 用 io.BytesIO 无句柄, 连续 5 次都能 save + read
+        """
+        for i in range(5):
+            exporter = MultiSheetRiskExporterXlsx()
+            file = exporter.save()
+            content = file.read()
+            self.assertTrue(
+                content.startswith(b"PK"),
+                f"第 {i+1} 次导出 xlsx 文件头不是 PK, 可能是空文件/损坏 (Windows 句柄冲突可能未修复)",
+            )
+
+    @unittest.skipUnless(sys.platform == "win32", "仅在 Windows 验证 close 幂等性")
+    def test_close_does_not_raise_after_windows_handle_released(self):
+        """真实 Windows: 验证 close() 幂等 (句柄已被 OS 回收场景)"""
+        exporter = MultiSheetRiskExporterXlsx()
+        file = exporter.save()
+        file.close()  # 先关闭 Django File wrapper
+        # 关键: BytesIO 关闭后再次 close 不会因 Windows 句柄已释放抛错
+        exporter.close()
+        exporter.close()  # 二次 close 必须幂等

--- a/src/backend/tests/test_risk/test_analyse_report.py
+++ b/src/backend/tests/test_risk/test_analyse_report.py
@@ -21,6 +21,7 @@ import io
 import json
 import sys
 import types
+import unittest
 from pathlib import Path
 from unittest import mock
 
@@ -1370,6 +1371,66 @@ class TestExportAnalyseReport(AnalyseReportTestBase):
                     "export_format": "markdown",
                 }
             )
+
+    def test_resolve_pdf_resource_handles_windows_drive_backslash(self):
+        """L1: 验证 Windows 盘符路径 (C:\\xxx) 走内置字体判断, 不被 urlparse 误判 scheme='c'"""
+        from urllib.parse import urlparse
+
+        export_resource = self.resource.risk.export_analyse_report
+        windows_path = "C:\\Windows\\Fonts\\arial.ttf"
+
+        # 前置条件: urlparse 确实会把 C:\\xxx 误判为 scheme='c', 这正是要修复的 bug
+        self.assertEqual(urlparse(windows_path).scheme, "c")
+
+        # 验证修复后: 走盘符路径判断逻辑, 不抛 Invalid URL
+        resolved = export_resource._resolve_pdf_resource(windows_path, None)
+        # 返回值要么是路径本身 (如果命中内置字体), 要么是 BLOCKED 占位
+        self.assertIn(
+            resolved,
+            [windows_path, export_resource._BLOCKED_PDF_RESOURCE_URI],
+            f"盘符路径应被识别为本地文件, 不应被 urlparse 当作 URL 解析. resolved={resolved!r}",
+        )
+
+    def test_resolve_pdf_resource_handles_windows_drive_forward_slash(self):
+        """L1: 验证 Windows 盘符路径 (D:/xxx) 同样被识别, 不被 urlparse 误判 scheme='d'"""
+        from urllib.parse import urlparse
+
+        export_resource = self.resource.risk.export_analyse_report
+        windows_path = "D:/fonts/simhei.ttf"
+
+        self.assertEqual(urlparse(windows_path).scheme, "d")
+
+        resolved = export_resource._resolve_pdf_resource(windows_path, None)
+        self.assertIn(
+            resolved,
+            [windows_path, export_resource._BLOCKED_PDF_RESOURCE_URI],
+        )
+
+    def test_resolve_pdf_resource_linux_absolute_path_blocked(self):
+        """L1: 反例验证 - Linux 绝对路径 /etc/passwd 仍然被拒, 防止正则回退"""
+        callback = self.resource.risk.export_analyse_report._resolve_pdf_resource
+        resolved = callback("/etc/passwd", None)
+        self.assertEqual(resolved, "data:image/gif;base64,R0lGODlhAQABAAAAACw=")
+
+    @unittest.skipUnless(sys.platform == "win32", "仅在 Windows 真实环境验证盘符拦截修复")
+    def test_resolve_pdf_resource_real_windows_path(self):
+        """L2a: 真实 Windows 环境 - 用 os.path.normpath 构造真实盘符路径, 验证不抛 Invalid URL 异常
+
+        修复前: urlparse(r"C:\\xxx") 在 Windows 上同样报错 scheme='c' → Invalid URL
+        修复后: 前置正则拦截, 走内置字体判断逻辑
+        """
+        import os
+
+        export_resource = self.resource.risk.export_analyse_report
+        # Windows 上 normpath(C:/Windows/Fonts) 不会带盘符, 用反斜杠构造真实盘符路径
+        windows_path = os.path.normpath("C:/Windows/Fonts/arial.ttf")
+
+        # 关键: 在 Windows 上真实调用不抛 ValueError: Invalid URL: 'c'
+        resolved = export_resource._resolve_pdf_resource(windows_path, None)
+        self.assertIn(
+            resolved,
+            [windows_path, export_resource._BLOCKED_PDF_RESOURCE_URI],
+        )
 
 
 class TestListAnalyseReportRisk(AnalyseReportTestBase):


### PR DESCRIPTION
# TAPD
--story=135744265

## 改动说明

本次修复 Windows 环境下 3 个跨平台兼容性问题，不影响 Linux/macOS 生产环境。

### 修复 ①：XLSX 导出器句柄冲突
- **文件**: `core/exporter/export.py`
- **问题**: `BaseXlsxFileExporter` 使用 `NamedTemporaryFile`，Windows 上连续导出报 `PermissionError [WinError 32]`
- **方案**: 改用 `io.BytesIO()`（xlsxwriter 官方推荐方式），`save()` 后 `seek(0)`
- **影响接口**: `POST /api/v1/risk/risk_export/`

### 修复 ②：PDF 导出盘符路径误判
- **文件**: `services/web/risk/resources/analyse_report.py`
- **问题**: `urlparse("C:\\xxx")` 误判 `scheme="c"`，PDF 导出抛 `Invalid URL`
- **方案**: 新增正则 `^[a-zA-Z]:[\\/]` 前置拦截盘符路径
- **影响接口**: `GET /api/v1/analyse_report/{report_id}/export/?export_format=pdf`

### 修复 ③：测试代码 YAML 读取跨平台
- **文件**: `tests/test_bk_plugins/test_ai_audit_report.py`
- **问题**: 测试代码里 `read_text()` 走系统默认编码，Windows GBK 解析 UTF-8 YAML 失败
- **方案**: 2 处 `read_text()` 显式传 `encoding="utf-8"`

## 变更文件清单

**生产代码（2 个）**：
- `core/exporter/export.py`（+5 -3）
- `services/web/risk/resources/analyse_report.py`（+15 -9）

**测试代码（3 个）**：
- `tests/test_bk_plugins/test_ai_audit_report.py`（+30 -2，两个 commit 都改了）
- `tests/test_core/test_exporter.py`（+136，新建）
- `tests/test_risk/test_analyse_report.py`（+61）

**合计**: 5 个文件，+247 -14

## 测试

| 指标 | 数值 |
|---|---|
| 修复前通过率 | 1846/1861（99.19%）|
| 修复后通过率 | 1861/1861（100%）|
| Linux/macOS 行为 | 不变 |
| L1 跨平台测试 | 10 个 |
| L2a Windows-only 测试 | 4 个（`@skipUnless(win32)`）|

## 已知遗漏

`services/web/query/export/file_exporter.py` 的 `XLSXExporter`（日志检索导出）存在相同问题，不在本 PR 范围。

## 变更类型
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor

## 影响范围
- 后端: 是
- 前端: 否
- 数据库: 否
- 配置: 否
