### PR TITLE
fix: AI 能力基座：MCP 访问异常，以及格式异常（非 json） --story=1069990729136644922

### DIFF
--- a/src/backend/apps/audit/apps.py
+++ b/src/backend/apps/audit/apps.py
@@ -23,3 +23,8 @@ from django.utils.translation import gettext_lazy
 class AuditConfig(AppConfig):
     name = "apps.audit"
     verbose_name = gettext_lazy("审计")
+
+    def ready(self):
+        from core.bk_resource_compat import apply_resource_viewset_request_data_compat
+
+        apply_resource_viewset_request_data_compat()

--- a/src/backend/config/default.py
+++ b/src/backend/config/default.py
@@ -160,7 +160,7 @@ REST_FRAMEWORK = {
     "DATETIME_FORMAT": "%Y-%m-%d %H:%M:%S",
     "NON_FIELD_ERRORS_KEY": "params_error",
     "DEFAULT_PARSER_CLASSES": (
-        "rest_framework.parsers.JSONParser",
+        "core.parsers.JSONObjectJSONParser",
         "rest_framework.parsers.FormParser",
         "rest_framework.parsers.MultiPartParser",
     ),

--- a/src/backend/core/bk_resource_compat.py
+++ b/src/backend/core/bk_resource_compat.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""`bk-resource==0.4.11` 的临时兼容补丁。"""
+
+from collections.abc import Mapping
+from functools import wraps
+
+from django.http import QueryDict
+from django.utils.translation import gettext
+from rest_framework.exceptions import ParseError
+
+
+def apply_resource_viewset_request_data_compat():
+    """避免 ResourceViewSet 合并路径参数时处理不可变或标量请求体。
+
+    `bk-resource==0.4.11` 会在路由模板中直接对 ``request.data`` 调用
+    ``update``。表单请求会得到不可变 ``QueryDict``，标量 JSON 则没有
+    ``update`` 方法，都会泄漏为 500。上游修复并升级依赖后应删除本补丁。
+    """
+    from bk_resource.viewsets import ResourceViewSet
+
+    if getattr(ResourceViewSet, "_bk_audit_request_data_compat_applied", False):
+        return
+
+    original_initial = ResourceViewSet.initial
+
+    @wraps(original_initial)
+    def initial(viewset, request, *args, **kwargs):
+        original_initial(viewset, request, *args, **kwargs)
+
+        # GET 请求在 bk-resource 模板内已通过 query_params.copy() 得到可变对象；
+        # 仅当存在路径参数时，非 GET 请求才会在模板内执行 request_data.update(...)
+        if request.method == "GET" or not viewset.kwargs:
+            return
+
+        request_data = request.data
+        if isinstance(request_data, QueryDict):
+            request._full_data = request_data.copy()
+        elif not isinstance(request_data, Mapping):
+            raise ParseError(gettext("请求体必须为 JSON/Form 对象，不能为字符串、数组或 null"))
+
+    ResourceViewSet.initial = initial
+    ResourceViewSet._bk_audit_request_data_compat_applied = True

--- a/src/backend/core/parsers.py
+++ b/src/backend/core/parsers.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from django.utils.translation import gettext
+from rest_framework.exceptions import ParseError
+from rest_framework.parsers import JSONParser
+
+
+class JSONObjectJSONParser(JSONParser):
+    """仅接受 JSON object，避免 ResourceViewSet 在合并路径参数时处理标量请求体。"""
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        data = super().parse(stream, media_type=media_type, parser_context=parser_context)
+        if not isinstance(data, dict):
+            raise ParseError(gettext("请求体必须为 JSON 对象，不能为字符串、数组或 null"))
+        return data

--- a/src/backend/services/web/tool/resources.py
+++ b/src/backend/services/web/tool/resources.py
@@ -918,9 +918,7 @@ class ExecuteTool(ToolBase):
                 ],
                 "page": 1,
                 "page_size": 100
-            },
-            "caller_resource_type": "risk",
-            "caller_resource_id": "R123"
+            }
         }
         ```
         response:
@@ -976,9 +974,7 @@ class ExecuteTool(ToolBase):
         ```json
         {
             "uid": "vision_tool_123",
-            "params": {},
-            "caller_resource_type": "risk",
-            "caller_resource_id": "R123"
+            "params": {}
         }
         ```
         response:
@@ -991,15 +987,27 @@ class ExecuteTool(ToolBase):
         }
         ```
 
-    4. 权限上下文（可选）
-        - 携带调用方上下文时，系统将基于调用方资源做统一鉴权：
-            - `caller_resource_type`：调用方资源类型（当前支持：`risk`）
-            - `caller_resource_id`：调用方资源实例 ID（如风险ID）
-            - `drill_field`：指定使用哪个字段的 drill_config 进行变量值校验
-            - `event_start_time`/`event_end_time`：事件时间范围（用于 list_event 获取事件数据）
-        - 行为说明：
-            - 命中且有权限：跳过原有工具权限校验，直接执行
-            - 命中但无权限：返回标准权限异常（包含可申请信息）
+    4. 风险下钻上下文（仅风险策略字段下钻时使用）
+        - 普通工具执行仅传 `uid` 和 `params`，不得传 `caller_resource_*`、`drill_field`、
+          `event_start_time`、`event_end_time`。
+        - 仅当 `uid` 来自当前风险的策略字段 `drill_config.tool.uid` 时，才传完整的风险下钻上下文：
+        ```json
+        {
+            "uid": "risk_drill_tool_123",
+            "params": {
+                "tool_variables": [
+                    {"raw_name": "username", "value": "admin"}
+                ]
+            },
+            "caller_resource_type": "risk",
+            "caller_resource_id": "R123",
+            "drill_field": "operator",
+            "event_start_time": "2026-07-28 00:00:00",
+            "event_end_time": "2026-07-29 00:00:00"
+        }
+        ```
+        - `drill_field` 使用该 `drill_config` 所属字段的 `field_name`；变量值按照对应 `drill_config.config`
+          组装，时间范围使用风险详情中的 `event_time`、`event_end_time`。
     """
 
     name = gettext_lazy("工具执行")

--- a/src/backend/support-files/apigw/definition.yaml
+++ b/src/backend/support-files/apigw/definition.yaml
@@ -4,11 +4,11 @@ spec_version: 2  # 如果之前接入过的，建议将 sepc_version改成 2，�
 release:
   # 发布版本号；
   # 资源配置更新，需更新此版本号才会发布资源版本，此版本号和 sdk 版本号一致，错误设置会影响调用方使用
-  version: "0.0.12"
+  version: "0.0.13"
   # 版本标题
-  title: "0.0.12"
+  title: "0.0.13"
   # 版本描述
-  comment: "补充用户态 MCP 风险下钻工具的条件必填参数与调用链说明"
+  comment: "MCP 请求体格式异常返回明确 4xx，并收敛风险下钻上下文说明"
 
 # 定义网关基本信息，用于命令 `sync_apigw_config`
 apigateway:

--- a/src/backend/support-files/apigw/resources.yaml
+++ b/src/backend/support-files/apigw/resources.yaml
@@ -2683,7 +2683,7 @@ paths:
         使用真实用户身份执行工具。默认直接执行：只传 params，不得传 caller_resource_type、
         caller_resource_id、drill_field、event_start_time、event_end_time，后端按用户的工具使用权限鉴权。
         仅当 path uid 来自当前风险 mcp_retrieve_risk_strategy_info 返回字段的 drill_config.tool.uid 时，才使用风险下钻模式：
-        必须同时传 caller_resource_type=risk、caller_resource_id=当前风险ID、drill_field=该 drill_config 所属字段的 field_name、
+        必须同时传入 caller_resource_type=risk、caller_resource_id=当前风险ID、drill_field=该 drill_config 所属字段的 field_name、
         event_start_time/event_end_time=同一风险 mcp_retrieve_risk 返回的 event_time/event_end_time，且按 drill_config.config
         组装 params.tool_variables。仅 params.tool_variables 非空不代表风险下钻，不能据此传 caller 上下文。
       tags: []

--- a/src/backend/support-files/apigw/resources.yaml
+++ b/src/backend/support-files/apigw/resources.yaml
@@ -2680,10 +2680,12 @@ paths:
     post:
       operationId: mcp_execute_tool
       description: >-
-        使用真实用户身份执行工具。风险下钻且 params.tool_variables 非空时，caller_resource_type=risk、
-        caller_resource_id、drill_field、event_start_time、event_end_time 必须同时传入；先调用 mcp_retrieve_risk，
-        使用返回的 event_time/event_end_time 填充时间范围，再按策略 drill_config 组装 params.tool_variables。
-        调用方风险权限或工具使用权限任一满足即可。
+        使用真实用户身份执行工具。默认直接执行：只传 params，不得传 caller_resource_type、
+        caller_resource_id、drill_field、event_start_time、event_end_time，后端按用户的工具使用权限鉴权。
+        仅当 path uid 来自当前风险 mcp_retrieve_risk_strategy_info 返回字段的 drill_config.tool.uid 时，才使用风险下钻模式：
+        必须同时传 caller_resource_type=risk、caller_resource_id=当前风险ID、drill_field=该 drill_config 所属字段的 field_name、
+        event_start_time/event_end_time=同一风险 mcp_retrieve_risk 返回的 event_time/event_end_time，且按 drill_config.config
+        组装 params.tool_variables。仅 params.tool_variables 非空不代表风险下钻，不能据此传 caller 上下文。
       tags: []
       parameters:
         - in: path
@@ -2706,7 +2708,7 @@ paths:
             properties:
               params:
                 type: object
-                description: 工具执行参数。风险下钻时按 retrieve_risk_strategy_info 返回的 drill_config.config 组装 tool_variables。
+                description: 工具执行参数。普通执行按工具自身参数传入；风险下钻时按 retrieve_risk_strategy_info 返回的 drill_config.config 组装 tool_variables。仅 tool_variables 非空不代表风险下钻。
                 properties:
                   tool_variables:
                     type: array
@@ -2735,25 +2737,25 @@ paths:
                     default: 100
               caller_resource_type:
                 type: string
-                description: 调用方资源类型。风险下钻且 params.tool_variables 非空时必填，固定传 risk，用于声明本次工具执行来自风险上下文。
+                description: 风险下钻上下文。普通工具执行不得传；仅当 path uid 来自当前风险策略字段的 drill_config.tool.uid 时传 risk。
               caller_resource_id:
                 type: string
-                description: 调用方资源实例ID。风险下钻且 params.tool_variables 非空时必填，传风险ID，应与 retrieve_risk_strategy_info 的 id 一致。
+                description: 风险下钻上下文。普通工具执行不得传；风险下钻时传当前风险ID，应与 retrieve_risk_strategy_info 的 risk_id 一致。
               drill_field:
                 type: string
                 description: >-
-                  指定使用哪个策略字段的 drill_config 进行变量值校验。风险下钻且 params.tool_variables 非空时必填，传所选字段的 field_name，
+                  风险下钻上下文。普通工具执行不得传；风险下钻时传当前 uid 所在 drill_config 对应字段的 field_name，
                   后端仅使用该字段下与当前 uid 匹配的 config 校验 params.tool_variables。
               event_start_time:
                 type: string
                 description: >-
-                  风险事件开始时间，用于后端调用 list_event 获取事件数据。风险下钻且 params.tool_variables 非空时必填，
-                  使用 mcp_retrieve_risk 返回的 event_time，并与 drill_field、event_end_time 一起传入。
+                  风险下钻上下文。普通工具执行不得传；风险下钻时使用 mcp_retrieve_risk 返回的 event_time，
+                  用于后端读取风险事件数据并校验变量值。
               event_end_time:
                 type: string
                 description: >-
-                  风险事件结束时间，用于后端调用 list_event 获取事件数据。风险下钻且 params.tool_variables 非空时必填，
-                  使用 mcp_retrieve_risk 返回的 event_end_time，并与 drill_field、event_start_time 一起传入。
+                  风险下钻上下文。普通工具执行不得传；风险下钻时使用 mcp_retrieve_risk 返回的 event_end_time，
+                  用于后端读取风险事件数据并校验变量值。
       responses:
         "200":
           description: 执行成功

--- a/src/backend/tests/test_bk_plugins/test_mcp_user_apigw_config.py
+++ b/src/backend/tests/test_bk_plugins/test_mcp_user_apigw_config.py
@@ -123,12 +123,14 @@ class TestMCPUserAPIGWConfig(SimpleTestCase):
         self.assertNotIn(("query", "lite_mode"), detail_parameters)
 
     def test_mcp_execute_tool_describes_risk_drill_required_context(self):
-        """风险下钻的条件必填参数及时间来源必须暴露给 MCP Agent。"""
+        """MCP 必须区分普通直调和风险策略字段下钻。"""
         operations = self._get_operations()
         execute_operation = operations["mcp_execute_tool"]
         strategy_operation = operations["mcp_retrieve_risk_strategy_info"]
 
-        self.assertIn("params.tool_variables 非空", execute_operation["description"])
+        self.assertIn("默认直接执行", execute_operation["description"])
+        self.assertIn("drill_config.tool.uid", execute_operation["description"])
+        self.assertIn("仅 params.tool_variables 非空不代表风险下钻", execute_operation["description"])
         self.assertIn("必须同时传入", execute_operation["description"])
         self.assertIn("mcp_retrieve_risk", strategy_operation["description"])
         self.assertIn("event_time/event_end_time", strategy_operation["description"])
@@ -143,7 +145,7 @@ class TestMCPUserAPIGWConfig(SimpleTestCase):
             "event_start_time",
             "event_end_time",
         ):
-            self.assertIn("风险下钻且 params.tool_variables 非空时必填", body_schema["properties"][field_name]["description"])
+            self.assertIn("普通工具执行不得传", body_schema["properties"][field_name]["description"])
 
     def test_all_audit_report_servers_use_new_mcp_resources(self):
         definition = self._load_definition()
@@ -162,7 +164,7 @@ class TestMCPUserAPIGWConfig(SimpleTestCase):
     def test_resource_change_advances_release_version(self):
         definition = self._load_definition()
 
-        self.assertEqual(definition["release"]["version"], "0.0.12")
+        self.assertEqual(definition["release"]["version"], "0.0.13")
         self.assertEqual(definition["release"]["title"], definition["release"]["version"])
 
     def _get_operations(self):

--- a/src/backend/tests/test_core/test_bk_resource_compat.py
+++ b/src/backend/tests/test_core/test_bk_resource_compat.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+from django.urls import resolve
+from rest_framework.parsers import JSONParser
+from rest_framework.test import APIRequestFactory
+
+from services.web.tool.views import ToolViewSet
+
+
+@override_settings(ROOT_URLCONF="services.web.urls")
+class TestBKResourceRequestDataCompat(SimpleTestCase):
+    def test_detail_resource_route_rejects_form_body_without_internal_error(self):
+        request = APIRequestFactory().post(
+            "/api/v1/namespaces/default/tool/tool-1/execute/",
+            data="params={}",
+            content_type="application/x-www-form-urlencoded",
+        )
+        view = resolve("/api/v1/namespaces/default/tool/tool-1/execute/").func
+        route = next(route for route in ToolViewSet.resource_routes if route.endpoint == "execute")
+
+        with (
+            mock.patch.object(ToolViewSet, "get_permissions", return_value=[]),
+            mock.patch.object(route.resource_class, "request", return_value={"tool_type": "api", "data": {}}),
+        ):
+            response = view(request, namespace="default", uid="tool-1")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_resource_route_rejects_scalar_body_without_internal_error(self):
+        request = APIRequestFactory().post(
+            "/api/v1/namespaces/default/tool/tool-1/execute/",
+            data='"{}"',
+            content_type="application/json",
+        )
+        view = resolve("/api/v1/namespaces/default/tool/tool-1/execute/").func
+        route = next(route for route in ToolViewSet.resource_routes if route.endpoint == "execute")
+
+        with (
+            mock.patch.object(ToolViewSet, "get_permissions", return_value=[]),
+            mock.patch.object(ToolViewSet, "parser_classes", [JSONParser]),
+            mock.patch.object(route.resource_class, "request", return_value={"tool_type": "api", "data": {}}),
+        ):
+            response = view(request, namespace="default", uid="tool-1")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("请求体必须为 JSON/Form 对象", str(response.data))

--- a/src/backend/tests/test_core/test_parsers.py
+++ b/src/backend/tests/test_core/test_parsers.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from io import BytesIO
+
+from django.test import SimpleTestCase
+from rest_framework.exceptions import ParseError
+
+from core.parsers import JSONObjectJSONParser
+
+
+class TestJSONObjectJSONParser(SimpleTestCase):
+    def parse(self, body):
+        return JSONObjectJSONParser().parse(
+            stream=BytesIO(body.encode()),
+            media_type="application/json",
+            parser_context={},
+        )
+
+    def test_accepts_json_object(self):
+        self.assertEqual(self.parse('{"params": {}}'), {"params": {}})
+
+    def test_rejects_non_object_json_body(self):
+        for body in ('"{\\"params\\": {}}"', "[]", "null"):
+            with self.subTest(body=body):
+                with self.assertRaisesMessage(ParseError, "请求体必须为 JSON 对象"):
+                    self.parse(body)

--- a/src/backend/tests/test_tool/test_mcp_user_tool_viewset.py
+++ b/src/backend/tests/test_tool/test_mcp_user_tool_viewset.py
@@ -24,7 +24,7 @@ from services.web.tool.resources import (
     MCPExecuteTool,
 )
 from services.web.tool.serializers import ExecuteToolRespSerializer
-from services.web.tool.views import MCPUserToolViewSet
+from services.web.tool.views import MCPUserToolViewSet, ToolViewSet
 from tests.base import TestCase
 
 
@@ -253,3 +253,37 @@ class TestMCPUserToolDetailViewSet(TestCase):
         self.assertNotIn("sql", result["config"])
         self.assertNotIn("referenced_tables", result["config"])
         self.assertNotIn("api_config", result["config"])
+
+
+class TestJSONBodyValidation(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = APIRequestFactory()
+
+    def test_mcp_execute_rejects_json_string_body(self):
+        view = MCPUserToolViewSet.as_view({"post": "execute"})
+        request = self.factory.post(
+            "/api/v1/namespaces/default/mcp_user/tool/tool-1/execute/",
+            '"{\\"params\\": {}}"',
+            content_type="application/json",
+        )
+
+        with mock.patch.object(MCPUserToolViewSet, "get_permissions", return_value=[]):
+            response = view(request, namespace="default", uid="tool-1")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("请求体必须为 JSON 对象", str(response.data))
+
+    def test_regular_execute_rejects_json_string_body(self):
+        view = ToolViewSet.as_view({"post": "execute"})
+        request = self.factory.post(
+            "/api/v1/namespaces/default/tool/tool-1/execute/",
+            '"{\\"params\\": {}}"',
+            content_type="application/json",
+        )
+
+        with mock.patch.object(ToolViewSet, "get_permissions", return_value=[]):
+            response = view(request, uid="tool-1")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("请求体必须为 JSON 对象", str(response.data))


### PR DESCRIPTION
统一拒绝非对象 JSON 请求体，避免 MCP 和常规接口返回 500

收敛 MCP 风险下钻上下文说明，并发布 APIGW 资源版本 0.0.13

全量测试 2061 项通过（跳过 4 项）