### PR TITLE
feat: AI日志检索全量导出自动聚合扩展字段子键清单 --story=136903803

### DIFF
--- a/src/backend/services/web/ai_assistant/services/log_export.py
+++ b/src/backend/services/web/ai_assistant/services/log_export.py
@@ -77,11 +77,24 @@ class MessageExportService:
         except ValidationError as error:
             raise InvalidMessageSnapshot() from error
         namespace = str((message.context_data or {}).get("namespace") or "")
+        export_config = dict(export_config or {})
+        # 扩展字段平铺开启且调用方未显式给子键清单时，从父消息的系统选择快照自动聚合
+        # （前端只需传 flatten_extension 开关，无需感知子键清单）
+        if export_config.get("flatten_extension") and not export_config.get("extension_keys"):
+            extension_keys = self._extract_extension_keys(message)
+            if extension_keys:
+                export_config["extension_keys"] = extension_keys
+                logger.info(
+                    "[MessageExportService] auto inject extension_keys for flatten export, "
+                    "message_id=%s, keys=%s",
+                    message.id,
+                    extension_keys,
+                )
         try:
             task = FullExportService.create_task(
                 condition=condition,
                 namespace=namespace,
-                export_config=export_config or {},
+                export_config=export_config,
                 task_name=FullExportService.build_task_name(str(message.uid)),
                 username=self.user,
             )
@@ -96,6 +109,36 @@ class MessageExportService:
             raise LogExportFailed() from error
         # resource 调用经 bk_resource 框架序列化后返回 ReturnDict（dict 子类），按键访问而非属性访问
         return {"export_task_id": task["id"], "status": task["status"]}
+
+    @staticmethod
+    def _extract_extension_keys(message: Message) -> list:
+        """从父消息聚合 extend_data 单层子键清单（保序去重）。
+
+        来源二选一：自然语言父消息的 context_data.system_selection.systems；
+        系统选择父消息的 output_data.systems。两者均为
+        systems[].extension_fields[]（SelectionFieldMeta dict 形态，raw_name+keys）。
+        """
+
+        parent = message.parent_message
+        if parent is None:
+            return []
+        if parent.message_type == MessageType.NATURAL_LANGUAGE_SEARCH:
+            systems = ((parent.context_data or {}).get("system_selection") or {}).get("systems") or []
+        else:
+            systems = (parent.output_data or {}).get("systems") or []
+        keys: list = []
+        seen: set = set()
+        for system in systems:
+            for field in (system or {}).get("extension_fields") or []:
+                if not isinstance(field, dict) or field.get("raw_name") != "extend_data":
+                    continue
+                # 一期下钻协议限单层，仅取第一层子键
+                field_keys = field.get("keys") or []
+                key = field_keys[0] if field_keys else ""
+                if isinstance(key, str) and key and key not in seen:
+                    seen.add(key)
+                    keys.append(key)
+        return keys
 
     def _get_success_log_search(self, *, message_uid: str) -> Message:
         """复用平台统一用户边界获取消息，再校验类型与状态。"""

--- a/src/backend/tests/test_ai_assistant/test_operation_and_export.py
+++ b/src/backend/tests/test_ai_assistant/test_operation_and_export.py
@@ -191,6 +191,104 @@ class TestMessageExport(AIAssistantPlatformTestCase):
             with self.assertRaises(LogExportPermissionDenied):
                 self.service.create_full_export(message_uid=str(message.uid), export_config={})
 
+    def _make_nl_parent_with_extension_fields(self, extension_fields):
+        from tests.test_ai_assistant.base import make_selection_output
+
+        selection = self.create_selection_message(output=make_selection_output())
+        nl_message = self.create_nl_message(parent=selection)
+        nl_message.context_data["system_selection"]["systems"][0]["extension_fields"] = extension_fields
+        nl_message.save(update_record=False, update_fields=["context_data"])
+        return nl_message
+
+    def test_full_export_auto_injects_extension_keys(self):
+        """flatten 开启且未传 extension_keys：从 NL 父消息的系统选择快照自动聚合（前端只传开关）"""
+
+        nl_parent = self._make_nl_parent_with_extension_fields(
+            [
+                {"raw_name": "extend_data", "keys": ["ticket_id"], "display_name": "工单ID"},
+                {"raw_name": "extend_data", "keys": ["operator"], "display_name": "经办人"},
+                {"raw_name": "extend_data", "keys": ["ticket_id"], "display_name": "重复子键去重"},
+                {"raw_name": "instance_data", "keys": ["name"], "display_name": "非 extend_data 容器忽略"},
+                {"raw_name": "extend_data", "keys": [], "display_name": "无子键忽略"},
+            ]
+        )
+        message = self.create_log_search_message(parent=nl_parent)
+        fake_task = {"id": 123, "status": "PENDING"}
+        with mock.patch(
+            "services.web.ai_assistant.services.log_export.FullExportService.create_task",
+            return_value=fake_task,
+        ) as mock_create:
+            self.service.create_full_export(
+                message_uid=str(message.uid),
+                export_config={"field_scope": "all", "flatten_extension": True, "fields": []},
+            )
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["export_config"]["extension_keys"], ["ticket_id", "operator"])
+
+    def test_full_export_explicit_extension_keys_not_overridden(self):
+        """显式传 extension_keys：后端不覆盖调用方清单"""
+
+        nl_parent = self._make_nl_parent_with_extension_fields(
+            [{"raw_name": "extend_data", "keys": ["ticket_id"], "display_name": "工单ID"}]
+        )
+        message = self.create_log_search_message(parent=nl_parent)
+        with mock.patch(
+            "services.web.ai_assistant.services.log_export.FullExportService.create_task",
+            return_value={"id": 1, "status": "PENDING"},
+        ) as mock_create:
+            self.service.create_full_export(
+                message_uid=str(message.uid),
+                export_config={
+                    "field_scope": "all",
+                    "flatten_extension": True,
+                    "extension_keys": ["custom_key"],
+                    "fields": [],
+                },
+            )
+        _, kwargs = mock_create.call_args
+        self.assertEqual(kwargs["export_config"]["extension_keys"], ["custom_key"])
+
+    def test_full_export_no_flatten_no_injection(self):
+        """flatten 未开启：不聚合不注入（原检索页语义零变化）"""
+
+        nl_parent = self._make_nl_parent_with_extension_fields(
+            [{"raw_name": "extend_data", "keys": ["ticket_id"], "display_name": "工单ID"}]
+        )
+        message = self.create_log_search_message(parent=nl_parent)
+        with mock.patch(
+            "services.web.ai_assistant.services.log_export.FullExportService.create_task",
+            return_value={"id": 1, "status": "PENDING"},
+        ) as mock_create:
+            self.service.create_full_export(
+                message_uid=str(message.uid),
+                export_config={"field_scope": "all", "fields": []},
+            )
+        _, kwargs = mock_create.call_args
+        self.assertNotIn("extension_keys", kwargs["export_config"])
+
+    def test_extract_extension_keys_from_selection_parent(self):
+        """父为系统选择消息：走 output_data.systems 路径同样聚合"""
+
+        from services.web.query.ai_assistant.schemas import SelectionFieldMeta
+
+        from tests.test_ai_assistant.base import make_selection_output
+
+        selection_output = make_selection_output()
+        selection_output.systems[0].extension_fields = [
+            SelectionFieldMeta(raw_name="extend_data", keys=["ticket_id"], display_name="工单ID")
+        ]
+        selection_message = self.create_selection_message(output=selection_output)
+        message = self.create_log_search_message(parent=selection_message)
+
+        keys = MessageExportService._extract_extension_keys(message)
+        self.assertEqual(keys, ["ticket_id"])
+
+    def test_extract_extension_keys_no_parent(self):
+        """无父消息（如历史数据）：返回空清单（平铺退化不生效，不报错）"""
+
+        message = self.create_log_search_message()
+        self.assertEqual(MessageExportService._extract_extension_keys(message), [])
+
     def test_export_rejects_non_success_message(self):
         """仅成功的日志检索消息支持导出。"""
 


### PR DESCRIPTION
- flatten_extension开启且未传extension_keys时从父消息系统选择快照自动聚合单层子键
- 前端只需传开关无需感知子键清单，显式传入时不覆盖
- 新增5个测试覆盖NL与系统选择两类父消息路径及去重与空场景