### PR TITLE
fix: 风险列表事件筛选后按风险去重分页 --story=138005149

### DIFF
--- a/src/backend/services/web/risk/converter/bkbase.py
+++ b/src/backend/services/web/risk/converter/bkbase.py
@@ -795,6 +795,9 @@ class MatchedEventSubqueryBuilder(SQLHelper):
 class FinalSelectAssembler(SQLHelper):
     """将基础风险查询与事件子查询组合成最终 SQL。"""
 
+    RISK_DEDUP_ALIAS = "ranked_risk"
+    RISK_ROW_NUMBER_ALIAS = "_risk_row_number"
+
     def __init__(self, resolver: BkBaseFieldResolver) -> None:
         self.resolver = resolver
 
@@ -804,15 +807,20 @@ class FinalSelectAssembler(SQLHelper):
         filtered_copy.set("order", None)
         filtered_copy.set("limit", None)
         filtered_copy.set("offset", None)
-        filtered_copy.set(
-            "expressions",
-            [
-                exp.alias_(
-                    exp.Literal.number(1),
-                    "__dummy",
-                )
-            ],
-        )
+        if matched_event is not None:
+            # JOIN 后同一风险可能对应多条匹配事件，count 必须按 risk_id 去重。
+            filtered_copy.set("expressions", [self.column("base_query", "risk_id")])
+            filtered_copy.set("distinct", exp.Distinct())
+        else:
+            filtered_copy.set(
+                "expressions",
+                [
+                    exp.alias_(
+                        exp.Literal.number(1),
+                        "__dummy",
+                    )
+                ],
+            )
         subquery = exp.Subquery(
             this=filtered_copy,
             alias=exp.TableAlias(this=exp.to_identifier("risk_count")),
@@ -832,39 +840,110 @@ class FinalSelectAssembler(SQLHelper):
         joined = self._join_events(base_query, matched_event)
 
         if matched_event is not None:
-            projections = list(joined.expressions or [exp.Star()])
-            if not projections:
-                projections = [exp.Star()]
-            projections.append(
-                # Expose matched event payload so Django objects can attach filtered_event_data later.
-                exp.alias_(
-                    self.column("matched_event", "event_data"),
-                    "__matched_event_data",
-                )
+            joined = self._project_matched_event_fields(joined)
+            joined = self._dedupe_joined_rows_by_risk_id(joined, order_fields)
+            order_expressions = self._build_order_expressions(
+                order_fields,
+                has_event_join=True,
+                table_alias=self.RISK_DEDUP_ALIAS,
+                event_ts_alias=self.RISK_DEDUP_ALIAS,
             )
-            event_order_field = self.resolver.event_order_field()
-            if event_order_field:
-                order_expression = exp.func(
-                    "JSON_EXTRACT_STRING",
-                    self.column("matched_event", "event_data"),
-                    exp.Literal.string(build_event_json_path(event_order_field)),
-                )
-                if self.resolver.event_order_requires_numeric_cast():
-                    order_expression = exp.Cast(this=order_expression, to=exp.DataType.build("DOUBLE"))
-                projections.append(exp.alias_(order_expression, "__order_event_field"))
-            joined.set("expressions", projections)
+        else:
+            order_expressions = self._build_order_expressions(order_fields, has_event_join=False)
 
-        order_expressions = self._build_order_expressions(order_fields, matched_event is not None)
         if order_expressions:
             joined = joined.order_by(*order_expressions)
-        if limit:
-            joined = joined.limit(int(limit))
-            if offset:
-                joined = joined.offset(int(offset))
-        elif offset:
-            joined = joined.offset(int(offset))
+        return self._apply_limit_offset(joined, limit=limit, offset=offset)
 
+    def _project_matched_event_fields(self, joined: exp.Select) -> exp.Select:
+        # 只投影 base_query.*，避免 JOIN 两侧 strategy_id/raw_event_id 重名后无法包进派生表。
+        # 必须用 Star 节点；exp.column("*") 会生成 base_query.`*`，Doris/Hive 不会展开。
+        projections = [
+            self._table_star("base_query"),
+            exp.alias_(
+                self.column("matched_event", "event_data"),
+                "__matched_event_data",
+            ),
+            exp.alias_(
+                self.column("matched_event", "dteventtimestamp"),
+                "dteventtimestamp",
+            ),
+        ]
+        event_order_expression = self._event_order_sql_expression()
+        if event_order_expression is not None:
+            projections.append(exp.alias_(event_order_expression, "__order_event_field"))
+        joined.set("expressions", projections)
         return joined
+
+    def _dedupe_joined_rows_by_risk_id(self, joined: exp.Select, order_fields: List[str]) -> exp.Select:
+        """同一风险只保留一条匹配事件，再交给 LIMIT 分页。"""
+        window = exp.Window(
+            this=exp.func("ROW_NUMBER"),
+            partition_by=[self.column("base_query", "risk_id")],
+            order=exp.Order(expressions=self._build_risk_dedup_window_order(order_fields)),
+        )
+        projections = list(joined.expressions)
+        projections.append(exp.alias_(window, self.RISK_ROW_NUMBER_ALIAS))
+        joined.set("expressions", projections)
+
+        ranked_subquery = exp.Subquery(
+            this=joined,
+            alias=exp.TableAlias(this=exp.to_identifier(self.RISK_DEDUP_ALIAS)),
+        )
+        return (
+            exp.select(exp.Star())
+            .from_(ranked_subquery)
+            .where(
+                exp.EQ(
+                    this=self.column(self.RISK_DEDUP_ALIAS, self.RISK_ROW_NUMBER_ALIAS),
+                    expression=exp.Literal.number("1"),
+                )
+            )
+        )
+
+    def _build_risk_dedup_window_order(self, order_fields: List[str]) -> List[exp.Expression]:
+        expressions = self._build_order_expressions(
+            order_fields,
+            has_event_join=True,
+            for_window=True,
+        )
+        if not expressions or not any(self._order_references_event_timestamp(item) for item in expressions):
+            expressions.append(
+                exp.Ordered(
+                    this=self.column("matched_event", "dteventtimestamp"),
+                    desc=True,
+                )
+            )
+        return expressions
+
+    def _event_order_sql_expression(self) -> Optional[exp.Expression]:
+        event_order_field = self.resolver.event_order_field()
+        if not event_order_field:
+            return None
+        order_expression: exp.Expression = exp.func(
+            "JSON_EXTRACT_STRING",
+            self.column("matched_event", "event_data"),
+            exp.Literal.string(build_event_json_path(event_order_field)),
+        )
+        if self.resolver.event_order_requires_numeric_cast():
+            return exp.Cast(this=order_expression, to=exp.DataType.build("DOUBLE"))
+        return order_expression
+
+    @staticmethod
+    def _apply_limit_offset(query: exp.Select, *, limit: int, offset: int) -> exp.Select:
+        if limit:
+            query = query.limit(int(limit))
+            if offset:
+                query = query.offset(int(offset))
+        elif offset:
+            query = query.offset(int(offset))
+        return query
+
+    @staticmethod
+    def _order_references_event_timestamp(order_expr: exp.Expression) -> bool:
+        return any(
+            isinstance(node, exp.Column) and node.name.lower() == "dteventtimestamp" for node in order_expr.walk()
+        )
 
     def _join_events(self, base_query: exp.Select, matched_event: Optional[exp.Subquery]) -> exp.Select:
         if matched_event is None:
@@ -894,6 +973,10 @@ class FinalSelectAssembler(SQLHelper):
         self,
         order_fields: List[str],
         has_event_join: bool,
+        *,
+        table_alias: str = "base_query",
+        event_ts_alias: str = "matched_event",
+        for_window: bool = False,
     ) -> List[exp.Expression]:
         """
         将 order_fields 列表转换为 sqlglot ORDER BY 表达式列表。
@@ -901,7 +984,7 @@ class FinalSelectAssembler(SQLHelper):
         每个字段按类型分三种处理方式：
         1. event_data.xxx  → __order_event_field + dteventtimestamp DESC（只取第一个，相同值按时间倒序）
         2. strategy__risk_level → CASE/WHEN 将 LOW/MIDDLE/HIGH 映射为 0/1/2 排名
-        3. 其他普通字段      → 直接引用 base_query.field_name
+        3. 其他普通字段      → 直接引用 table_alias.field_name
         """
         if not order_fields:
             return []
@@ -913,22 +996,36 @@ class FinalSelectAssembler(SQLHelper):
                 (f for f in order_fields if f.lstrip("-").startswith(self.resolver.EVENT_DATA_PREFIX)), None
             )
             if event_raw is not None:
+                if for_window:
+                    # 窗口函数与 SELECT 别名同层，不能引用 __order_event_field。
+                    event_order_expr = self._event_order_sql_expression()
+                else:
+                    event_order_expr = self.column(table_alias, "__order_event_field")
                 return [
-                    exp.Ordered(this=exp.column("__order_event_field"), desc=event_raw.startswith("-")),
-                    exp.Ordered(this=self.column("matched_event", "dteventtimestamp"), desc=True),
+                    exp.Ordered(this=event_order_expr, desc=event_raw.startswith("-")),
+                    exp.Ordered(this=self.column(event_ts_alias, "dteventtimestamp"), desc=True),
                 ]
 
         expressions = []
         for field in order_fields:
             bare = field.lstrip("-")
             descending = field.startswith("-")
+            column = self._order_column(bare, table_alias=table_alias)
 
             if bare == RISK_LEVEL_ORDER_FIELD:
-                rank_expr = self._build_risk_level_rank_expression(self._base_query_column(bare))
+                rank_expr = self._build_risk_level_rank_expression(column)
                 expressions.append(exp.Ordered(this=rank_expr, desc=descending))
             else:
-                expressions.append(exp.Ordered(this=self._base_query_column(bare), desc=descending))
+                expressions.append(exp.Ordered(this=column, desc=descending))
         return expressions
+
+    def _order_column(self, field_name: str, *, table_alias: str) -> exp.Column:
+        normalized = field_name.split("__")[-1] if "__" in field_name else field_name
+        return self.column(table_alias, normalized)
+
+    @staticmethod
+    def _table_star(alias: str) -> exp.Column:
+        return exp.Column(this=exp.Star(), table=exp.to_identifier(alias))
 
     def _build_join_timestamp_conditions(self, alias: str) -> List[exp.Expression]:
         event_timestamp = self.column(alias, "dteventtimestamp")
@@ -949,10 +1046,6 @@ class FinalSelectAssembler(SQLHelper):
                 exp.Literal.number(str(index)),
             )
         return case_expr.else_(exp.Literal.number("-1"))
-
-    def _base_query_column(self, field_name: str) -> exp.Column:
-        normalized = field_name.split("__")[-1] if "__" in field_name else field_name
-        return self.column("base_query", normalized)
 
 
 class BkBaseCountQueryBuilder:

--- a/src/backend/tests/test_risk/test_list_risk_serializer.py
+++ b/src/backend/tests/test_risk/test_list_risk_serializer.py
@@ -17,10 +17,11 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import datetime
+from textwrap import dedent
 
 from django.test import SimpleTestCase
 from django.utils import timezone
-from sqlglot import exp
+from sqlglot import exp, parse_one
 
 from services.web.common.constants import ScopeType
 from services.web.risk.constants import (
@@ -387,10 +388,191 @@ class TestBkBaseEventOrdering(SimpleTestCase):
         return resolver, data_query
 
     def _extract_order_alias(self, select_expression: exp.Select) -> exp.Alias:
-        for expression in select_expression.expressions or []:
-            if isinstance(expression, exp.Alias) and expression.alias_or_name == "__order_event_field":
-                return expression
+        for node in select_expression.walk():
+            if isinstance(node, exp.Alias) and node.alias_or_name == "__order_event_field":
+                return node
         raise AssertionError("order field alias not found")
+
+    def _build_count_and_data_query(
+        self,
+        *,
+        event_filters,
+        order_fields=None,
+        duplicate_field_map=None,
+        limit=20,
+        offset=0,
+    ):
+        order_fields = order_fields or []
+        resolver = BkBaseFieldResolver(
+            order_fields=order_fields,
+            event_filters=event_filters,
+            duplicate_field_map=duplicate_field_map or {},
+        )
+        base_expression = exp.select(
+            exp.column("risk_id", table="risk"),
+            exp.column("strategy_id", table="risk"),
+            exp.column("raw_event_id", table="risk"),
+            exp.column("event_time", table="risk"),
+            exp.column("event_end_time", table="risk"),
+            exp.column("last_operate_time", table="risk"),
+        ).from_("risk")
+        components = BkBaseQueryComponentsBuilder(
+            resolver=resolver,
+            duplicate_field_map=duplicate_field_map or {},
+            thedate_range=None,
+            table_name="risk_event",
+        ).build(base_expression)
+        assembler = FinalSelectAssembler(resolver)
+        count_query = assembler.assemble_count_query(components.base_query, components.matched_event)
+        data_query = assembler.assemble_data_query(
+            components.base_query,
+            components.matched_event,
+            order_fields=order_fields,
+            limit=limit,
+            offset=offset,
+        )
+        return count_query, data_query
+
+    @staticmethod
+    def _normalize_sql(sql: str) -> str:
+        return " ".join(dedent(sql).replace("`", "").split())
+
+    def _assert_sql(self, query: exp.Expression, expected: str) -> None:
+        actual_pretty = query.sql(dialect="mysql", pretty=True)
+        actual = self._canonical_sql(query.sql(dialect="mysql"))
+        expected_sql = self._canonical_sql(expected)
+        self.assertEqual(actual, expected_sql, msg=f"\nactual SQL:\n{actual_pretty}")
+
+    @classmethod
+    def _canonical_sql(cls, sql: str) -> str:
+        parsed = parse_one(cls._normalize_sql(sql), read="mysql")
+        return cls._normalize_sql(parsed.sql(dialect="mysql"))
+
+    @staticmethod
+    def _risk_subquery_sql() -> str:
+        return """
+        (
+          SELECT
+            risk.risk_id,
+            risk.strategy_id,
+            risk.raw_event_id,
+            risk.event_time,
+            risk.event_end_time,
+            risk.last_operate_time
+          FROM risk
+        ) AS base_query
+        """
+
+    @staticmethod
+    def _default_event_partition_sql() -> str:
+        return """
+        PARTITION BY matched_event_src_filtered.strategy_id,
+          COALESCE(
+            matched_event_src_filtered.raw_event_id,
+            CAST(matched_event_src_filtered.dteventtimestamp AS CHAR)
+          )
+        """
+
+    @staticmethod
+    def _duplicate_event_partition_sql() -> str:
+        return """
+        PARTITION BY matched_event_src_filtered.strategy_id,
+          CASE
+            WHEN matched_event_src_filtered.strategy_id = 1001
+            THEN CONCAT_WS(
+              '||',
+              COALESCE(CAST(JSON_EXTRACT_STRING(matched_event_src_filtered.event_data, '$.user_id') AS CHAR), ''),
+              COALESCE(CAST(JSON_EXTRACT_STRING(matched_event_src_filtered.event_data, '$.group_name') AS CHAR), '')
+            )
+            ELSE COALESCE(
+              matched_event_src_filtered.raw_event_id,
+              CAST(matched_event_src_filtered.dteventtimestamp AS CHAR)
+            )
+          END
+        """
+
+    @classmethod
+    def _matched_event_join_sql(cls, *, where_sql: str, partition_sql: str) -> str:
+        return f"""
+        INNER JOIN (
+          SELECT
+            matched_event_src_ranked.strategy_id,
+            matched_event_src_ranked.raw_event_id,
+            matched_event_src_ranked.event_data,
+            matched_event_src_ranked.dteventtimestamp
+          FROM (
+            SELECT
+              matched_event_src_filtered.strategy_id,
+              matched_event_src_filtered.raw_event_id,
+              matched_event_src_filtered.event_data,
+              matched_event_src_filtered.dteventtimestamp,
+              ROW_NUMBER() OVER (
+                {partition_sql}
+                ORDER BY matched_event_src_filtered.dteventtimestamp DESC,
+                  matched_event_src_filtered.raw_event_id DESC
+              ) AS _row_number
+            FROM (
+              SELECT
+                matched_event_src.strategy_id,
+                matched_event_src.raw_event_id,
+                matched_event_src.event_data,
+                matched_event_src.dteventtimestamp
+              FROM risk_event AS matched_event_src
+              WHERE {where_sql}
+            ) AS matched_event_src_filtered
+          ) AS matched_event_src_ranked
+          WHERE matched_event_src_ranked._row_number = 1
+        ) AS matched_event
+          ON (
+            (
+              matched_event.strategy_id = base_query.strategy_id
+              AND matched_event.raw_event_id = base_query.raw_event_id
+            )
+            AND matched_event.dteventtimestamp >= UNIX_TIMESTAMP(base_query.event_time) * 1000
+          )
+          AND matched_event.dteventtimestamp < UNIX_TIMESTAMP(base_query.event_end_time + INTERVAL 1 SECOND) * 1000
+        """
+
+    @classmethod
+    def _expected_join_count_sql(cls, *, where_sql: str, partition_sql: str) -> str:
+        return f"""
+        SELECT COUNT(*) AS count
+        FROM (
+          SELECT DISTINCT base_query.risk_id
+          FROM {cls._risk_subquery_sql()}
+          {cls._matched_event_join_sql(where_sql=where_sql, partition_sql=partition_sql)}
+        ) AS risk_count
+        LIMIT 1
+        """
+
+    @classmethod
+    def _expected_join_data_sql(
+        cls,
+        *,
+        where_sql: str,
+        partition_sql: str,
+        risk_window_sql: str,
+        select_extras_sql: str = "",
+        outer_order_sql: str = "",
+        limit_sql: str = "LIMIT 20",
+    ) -> str:
+        extras = f", {select_extras_sql}" if select_extras_sql else ""
+        outer_order = f" ORDER BY {outer_order_sql}" if outer_order_sql else ""
+        return f"""
+        SELECT *
+        FROM (
+          SELECT
+            base_query.*,
+            matched_event.event_data AS __matched_event_data,
+            matched_event.dteventtimestamp AS dteventtimestamp{extras},
+            ROW_NUMBER() OVER ({risk_window_sql}) AS _risk_row_number
+          FROM {cls._risk_subquery_sql()}
+          {cls._matched_event_join_sql(where_sql=where_sql, partition_sql=partition_sql)}
+        ) AS ranked_risk
+        WHERE ranked_risk._risk_row_number = 1
+        {outer_order}
+        {limit_sql}
+        """
 
     def test_numeric_filters_cast_order_field(self):
         resolver, select_expr = self._build_final_query(
@@ -482,6 +664,177 @@ class TestBkBaseEventOrdering(SimpleTestCase):
         )
         components = components_builder.build(base_expression)
         self.assertIsNone(components.matched_event)
+
+    def test_count_query_distincts_risk_id_after_event_join(self):
+        """JOIN 事件后 count 应按 risk_id 去重，避免把同一风险的多条匹配事件算进 total。"""
+        event_filters = [
+            {
+                "field": "latency",
+                "display_name": "Latency",
+                "operator": EventFilterOperator.EQUAL.value,
+                "value": "1",
+            }
+        ]
+        count_query, _ = self._build_count_and_data_query(event_filters=event_filters)
+        self._assert_sql(
+            count_query,
+            self._expected_join_count_sql(
+                where_sql="JSON_EXTRACT_STRING(matched_event_src.event_data, '$.latency') = '1'",
+                partition_sql=self._default_event_partition_sql(),
+            ),
+        )
+
+    def test_count_query_without_event_join_keeps_row_count(self):
+        """无事件 JOIN 时 count / data 都不走风险去重。"""
+        count_query, data_query = self._build_count_and_data_query(
+            event_filters=[],
+            order_fields=["-last_operate_time", "-risk_id"],
+        )
+        self._assert_sql(
+            count_query,
+            f"""
+            SELECT COUNT(*) AS count
+            FROM (
+              SELECT 1 AS __dummy
+              FROM {self._risk_subquery_sql()}
+            ) AS risk_count
+            LIMIT 1
+            """,
+        )
+        self._assert_sql(
+            data_query,
+            f"""
+            SELECT *
+            FROM {self._risk_subquery_sql()}
+            ORDER BY base_query.last_operate_time DESC, base_query.risk_id DESC
+            LIMIT 20
+            """,
+        )
+
+    def test_data_query_dedupes_by_risk_id_before_limit(self):
+        """分页 LIMIT 必须作用在按 risk_id 去重之后，否则首页会被同一风险占满。"""
+        event_filters = [
+            {
+                "field": "dept",
+                "display_name": "Dept",
+                "operator": EventFilterOperator.CONTAINS.value,
+                "value": "ops-dept",
+            }
+        ]
+        count_query, data_query = self._build_count_and_data_query(
+            event_filters=event_filters,
+            order_fields=["-last_operate_time", "-risk_id"],
+            duplicate_field_map={1001: {"data": ["user_id", "group_name"]}},
+            limit=20,
+            offset=0,
+        )
+        where_sql = "JSON_EXTRACT_STRING(matched_event_src.event_data, '$.dept') LIKE '%ops-dept%'"
+        partition_sql = self._duplicate_event_partition_sql()
+        self._assert_sql(
+            count_query,
+            self._expected_join_count_sql(where_sql=where_sql, partition_sql=partition_sql),
+        )
+        self._assert_sql(
+            data_query,
+            self._expected_join_data_sql(
+                where_sql=where_sql,
+                partition_sql=partition_sql,
+                risk_window_sql=(
+                    "PARTITION BY base_query.risk_id "
+                    "ORDER BY base_query.last_operate_time DESC, base_query.risk_id DESC, "
+                    "matched_event.dteventtimestamp DESC"
+                ),
+                outer_order_sql="ranked_risk.last_operate_time DESC, ranked_risk.risk_id DESC",
+                limit_sql="LIMIT 20",
+            ),
+        )
+
+    def test_data_query_applies_offset_after_risk_dedupe(self):
+        """第二页 OFFSET 必须作用在按 risk_id 去重之后。"""
+        event_filters = [
+            {
+                "field": "dept",
+                "display_name": "Dept",
+                "operator": EventFilterOperator.CONTAINS.value,
+                "value": "ops-dept",
+            }
+        ]
+        _, data_query = self._build_count_and_data_query(
+            event_filters=event_filters,
+            order_fields=["-last_operate_time", "-risk_id"],
+            limit=20,
+            offset=20,
+        )
+        self._assert_sql(
+            data_query,
+            self._expected_join_data_sql(
+                where_sql="JSON_EXTRACT_STRING(matched_event_src.event_data, '$.dept') LIKE '%ops-dept%'",
+                partition_sql=self._default_event_partition_sql(),
+                risk_window_sql=(
+                    "PARTITION BY base_query.risk_id "
+                    "ORDER BY base_query.last_operate_time DESC, base_query.risk_id DESC, "
+                    "matched_event.dteventtimestamp DESC"
+                ),
+                outer_order_sql="ranked_risk.last_operate_time DESC, ranked_risk.risk_id DESC",
+                limit_sql="LIMIT 20 OFFSET 20",
+            ),
+        )
+
+    def test_data_query_dedupes_without_order_fields(self):
+        """未指定排序时，LIMIT 前仍须按 risk_id 去重。"""
+        event_filters = [
+            {
+                "field": "latency",
+                "display_name": "Latency",
+                "operator": EventFilterOperator.EQUAL.value,
+                "value": "1",
+            }
+        ]
+        _, data_query = self._build_count_and_data_query(
+            event_filters=event_filters,
+            order_fields=[],
+            limit=10,
+        )
+        self._assert_sql(
+            data_query,
+            self._expected_join_data_sql(
+                where_sql="JSON_EXTRACT_STRING(matched_event_src.event_data, '$.latency') = '1'",
+                partition_sql=self._default_event_partition_sql(),
+                risk_window_sql="PARTITION BY base_query.risk_id ORDER BY matched_event.dteventtimestamp DESC",
+                limit_sql="LIMIT 10",
+            ),
+        )
+
+    def test_window_order_uses_json_extract_not_select_alias(self):
+        """窗口 ORDER BY 与 SELECT 别名同层，必须用 JSON_EXTRACT 而不能引用 __order_event_field。"""
+        _, data_query = self._build_count_and_data_query(
+            event_filters=[
+                {
+                    "field": "latency",
+                    "display_name": "Latency",
+                    "operator": EventFilterOperator.EQUAL.value,
+                    "value": "slow",
+                }
+            ],
+            order_fields=["-event_data.latency"],
+            limit=0,
+            offset=0,
+        )
+        self._assert_sql(
+            data_query,
+            self._expected_join_data_sql(
+                where_sql="JSON_EXTRACT_STRING(matched_event_src.event_data, '$.latency') = 'slow'",
+                partition_sql=self._default_event_partition_sql(),
+                select_extras_sql="JSON_EXTRACT_STRING(matched_event.event_data, '$.latency') AS __order_event_field",
+                risk_window_sql=(
+                    "PARTITION BY base_query.risk_id "
+                    "ORDER BY JSON_EXTRACT_STRING(matched_event.event_data, '$.latency') DESC, "
+                    "matched_event.dteventtimestamp DESC"
+                ),
+                outer_order_sql="ranked_risk.__order_event_field DESC, ranked_risk.dteventtimestamp DESC",
+                limit_sql="",
+            ),
+        )
 
 
 class TestListRiskRequestSerializerHasReport(SimpleTestCase):

--- a/src/backend/tests/test_risk/test_retrieve_risk.py
+++ b/src/backend/tests/test_risk/test_retrieve_risk.py
@@ -475,6 +475,45 @@ class TestListRiskResource(TestCase):
         self.assertEqual(results[0]["risk_id"], self.risk.risk_id)
         self.assertEqual(results[0]["event_data"], matched_event)
 
+    def test_list_risk_via_bkbase_dedupes_join_rows_before_pagination(self):
+        sql_log = []
+
+        def fake_query_sync(sql):
+            sql_log.append(sql)
+            if "COUNT" in sql.upper():
+                return {"list": [{"count": 2}]}
+            return {
+                "list": [
+                    {
+                        "risk_id": self.risk.risk_id,
+                        "strategy_id": self.risk.strategy_id,
+                        "raw_event_id": self.risk.raw_event_id,
+                        "__matched_event_data": json.dumps({"ip": "127.0.0.1"}),
+                    }
+                ]
+            }
+
+        payload = {
+            "title": "bkbase-title",
+            "sort": ["-last_operate_time", "-risk_id"],
+            "event_filters": [
+                {
+                    "field": "ip",
+                    "display_name": "Source IP",
+                    "operator": EventFilterOperator.CONTAINS.value,
+                    "value": "127.0",
+                }
+            ],
+        }
+
+        with mock.patch("bk_resource.api.bk_base.query_sync", side_effect=fake_query_sync):
+            data = self._call_resource(payload)
+
+        self.assertEqual(len(sql_log), 2)
+        assert_hive_sql(self, sql_log)
+        self.assertEqual(len(data["results"]), 1)
+        self.assertEqual(data["results"][0]["risk_id"], self.risk.risk_id)
+
     def test_list_risk_via_bkbase_order_by_event_data_field(self):
         sql_log = []
 
@@ -511,13 +550,6 @@ class TestListRiskResource(TestCase):
             data = self._call_resource(payload)
 
         self.assertEqual(len(sql_log), 2)
-        _, data_sql = sql_log
-        normalized_sql = data_sql.replace("`", "")
-        normalized_upper = normalized_sql.upper()
-        self.assertIn("__ORDER_EVENT_FIELD", normalized_upper)
-        self.assertIn("__MATCHED_EVENT_DATA", normalized_upper)
-        self.assertIn("ORDER BY __ORDER_EVENT_FIELD DESC", normalized_upper)
-        self.assertIn("MATCHED_EVENT.DTEVENTTIMESTAMP DESC", normalized_upper)
         assert_hive_sql(self, sql_log)
 
         results = data["results"]


### PR DESCRIPTION
- JOIN 匹配事件后 count 与 LIMIT 改为按唯一 risk_id 计算，避免 total 虚高、首页被同一风险占满
- 补充去重、OFFSET、列名唯一及无事件筛选路径的回归测试
- assembler 单测按完整 SQL 产物断言 count/data/OFFSET/空排序/事件字段排序
- 去掉生产策略字段与部门信息，资源层单测只保留 hive 解析与结果校验